### PR TITLE
Add Meta Ad Library search API

### DIFF
--- a/ads.http
+++ b/ads.http
@@ -1,0 +1,7 @@
+### Search Meta ads for financial services in the UK
+GET http://localhost:8000/ads?industry=finance&country=GB&limit=10
+Accept: application/json
+
+### Search Meta ads for technology in the default country
+GET http://localhost:8000/ads?industry=technology
+Accept: application/json

--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+"""FastAPI application exposing the Meta ads search endpoint."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Query, status
+from fastapi.responses import JSONResponse
+
+from meta_client import MetaAPIError, MetaTimeoutError, fetch_ads
+from models import AdsQuery, AdsResponse
+
+logging.basicConfig(level=logging.INFO)
+app = FastAPI(title="Meta Ads Search API")
+
+
+async def _query_dependency(
+    industry: Annotated[
+        str,
+        Query(..., min_length=2, description="Industry keyword to search for."),
+    ],
+    country: Annotated[
+        str,
+        Query(min_length=2, max_length=2, description="Two letter ISO country code (default GB)."),
+    ] = "GB",
+    limit: Annotated[
+        int,
+        Query(ge=1, le=100, description="Maximum number of ads to return (max 100)."),
+    ] = 50,
+) -> AdsQuery:
+    """Build the validated query model for downstream use."""
+
+    return AdsQuery(industry=industry, country=country, limit=limit)
+
+
+@app.get("/ads", response_model=AdsResponse)
+async def get_ads(query: AdsQuery = Depends(_query_dependency)) -> AdsResponse:
+    """Search the Meta Ad Library and return normalised ads."""
+
+    token = os.getenv("META_ADLIB_TOKEN")
+    if not token:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"error": "META_ADLIB_TOKEN not set"},
+        )
+
+    try:
+        ads = await fetch_ads(query, token)
+    except MetaTimeoutError:
+        return JSONResponse(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            content={"error": "Upstream timeout"},
+        )
+    except MetaAPIError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    return AdsResponse(query=query, count=len(ads), results=ads)

--- a/meta_client.py
+++ b/meta_client.py
@@ -1,0 +1,185 @@
+"""Client helpers for talking to the Meta Ad Library."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from collections import deque
+from typing import Any, Deque, Dict, Iterable, List, Optional
+
+import httpx
+
+from models import AdsQuery, NormalisedAd
+
+LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://graph.facebook.com/v23.0/ads_archive"
+HTTP_TIMEOUT = 30.0
+RATE_LIMIT_PER_SECOND = 5
+RATE_LIMIT_WINDOW = 1.0
+RATE_LIMIT_JITTER_RANGE = (0.05, 0.15)
+PAGE_DELAY_SECONDS = 0.15
+
+_request_lock = asyncio.Lock()
+_request_timestamps: Deque[float] = deque()
+
+
+class MetaAPIError(Exception):
+    """Raised when the Meta API returns an error response."""
+
+    def __init__(self, status_code: int, code: Optional[int], message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class MetaTimeoutError(Exception):
+    """Raised when the Meta API request times out."""
+
+
+async def _wait_for_rate_limit_slot() -> None:
+    """Ensure we do not exceed the configured rate limit."""
+
+    while True:
+        async with _request_lock:
+            now = time.monotonic()
+            while _request_timestamps and now - _request_timestamps[0] >= RATE_LIMIT_WINDOW:
+                _request_timestamps.popleft()
+            if len(_request_timestamps) < RATE_LIMIT_PER_SECOND:
+                _request_timestamps.append(now)
+                return
+            wait_time = RATE_LIMIT_WINDOW - (now - _request_timestamps[0])
+        jitter = random.uniform(*RATE_LIMIT_JITTER_RANGE)
+        await asyncio.sleep(max(wait_time, 0.0) + jitter)
+
+
+def _first_or_none(values: Any) -> Optional[str]:
+    """Return the first value from a list-like object, or the value itself."""
+
+    if isinstance(values, list):
+        return values[0] if values else None
+    if isinstance(values, tuple):
+        return values[0] if values else None
+    if isinstance(values, str):
+        return values
+    return None
+
+
+def _normalise_record(record: Dict[str, Any]) -> NormalisedAd:
+    """Convert a raw Meta record into our normalised schema."""
+
+    advertiser = record.get("page_name")
+    title = _first_or_none(record.get("ad_creative_link_titles"))
+    body = _first_or_none(record.get("ad_creative_bodies"))
+    snapshot_url = record.get("ad_snapshot_url")
+    start_time = record.get("ad_delivery_start_time")
+    stop_time = record.get("ad_delivery_stop_time") or None
+    creation_time = record.get("ad_creation_time")
+    last_seen = stop_time or creation_time
+    status = "inactive" if stop_time else "active"
+    platforms = record.get("publisher_platforms")
+    if platforms is not None and not isinstance(platforms, list):
+        platforms = [str(platforms)]
+
+    return NormalisedAd(
+        advertiser=advertiser,
+        title=title,
+        body=body,
+        creative_url=snapshot_url,
+        first_seen=start_time,
+        last_seen=last_seen,
+        status=status,
+        platforms=platforms,
+        snapshot_url=snapshot_url,
+    )
+
+
+def _sort_ads(ads: Iterable[NormalisedAd]) -> List[NormalisedAd]:
+    """Return ads sorted by last seen then first seen, both descending."""
+
+    return sorted(
+        ads,
+        key=lambda ad: ((ad.last_seen or ""), (ad.first_seen or "")),
+        reverse=True,
+    )
+
+
+async def fetch_ads(query: AdsQuery, token: str) -> List[NormalisedAd]:
+    """Fetch and normalise ads from the Meta Ad Library."""
+
+    params = {
+        "search_terms": query.industry,
+        "ad_active_status": "ALL",
+        "ad_reached_countries": query.country,
+        "fields": (
+            "ad_creation_time,ad_delivery_start_time,ad_delivery_stop_time,"
+            "ad_snapshot_url,page_id,page_name,ad_creative_bodies,"
+            "ad_creative_link_titles,ad_creative_link_descriptions,publisher_platforms"
+        ),
+        "limit": query.limit,
+        "access_token": token,
+    }
+
+    raw_records: List[Dict[str, Any]] = []
+    next_url: Optional[str] = None
+    page_count = 0
+    start_time = time.perf_counter()
+
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            while True:
+                await _wait_for_rate_limit_slot()
+                if next_url:
+                    response = await client.get(next_url)
+                else:
+                    response = await client.get(BASE_URL, params=params)
+                page_count += 1
+
+                if response.status_code != httpx.codes.OK:
+                    try:
+                        payload = response.json()
+                    except ValueError:  # pragma: no cover
+                        payload = {"error": {"message": response.text}}
+                    error = payload.get("error", {})
+                    raise MetaAPIError(
+                        status_code=response.status_code,
+                        code=error.get("code"),
+                        message=error.get("message", "Meta API error"),
+                    )
+
+                payload = response.json()
+                data = payload.get("data", [])
+                raw_records.extend(data)
+                if len(raw_records) >= query.limit:
+                    break
+                paging = payload.get("paging", {})
+                next_url = paging.get("next")
+                if not next_url:
+                    break
+                await asyncio.sleep(PAGE_DELAY_SECONDS)
+    except (
+        httpx.ConnectTimeout,
+        httpx.ReadTimeout,
+        httpx.WriteTimeout,
+        httpx.PoolTimeout,
+        httpx.TimeoutException,
+    ) as exc:
+        raise MetaTimeoutError(str(exc)) from exc
+    finally:
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        LOGGER.info(
+            "Meta request industry=%s country=%s pages=%s duration_ms=%s",
+            query.industry,
+            query.country,
+            page_count,
+            duration_ms,
+        )
+
+    if raw_records:
+        raw_records = raw_records[: query.limit]
+
+    normalised = [_normalise_record(record) for record in raw_records]
+    return _sort_ads(normalised)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,59 @@
+"""Pydantic models for the Meta ads search API."""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AdsQuery(BaseModel):
+    """Validated query parameters for an ads search request."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    industry: str = Field(..., min_length=2, description="Industry keyword to search for.")
+    country: str = Field(
+        default="GB",
+        min_length=2,
+        max_length=2,
+        description="Two letter ISO country code.",
+    )
+    limit: int = Field(
+        default=50,
+        ge=1,
+        le=100,
+        description="Maximum number of ads to return (max 100).",
+    )
+
+    @field_validator("country")
+    @classmethod
+    def uppercase_country(cls, value: str) -> str:
+        """Ensure the supplied country code is upper case."""
+
+        return value.upper()
+
+
+class NormalisedAd(BaseModel):
+    """Normalised representation of a Meta ad."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    source: Literal["meta"] = "meta"
+    advertiser: Optional[str] = None
+    title: Optional[str] = None
+    body: Optional[str] = None
+    creative_url: Optional[str] = None
+    first_seen: Optional[str] = None
+    last_seen: Optional[str] = None
+    status: Optional[Literal["active", "inactive"]] = None
+    platforms: Optional[List[str]] = None
+    snapshot_url: Optional[str] = None
+
+
+class AdsResponse(BaseModel):
+    """API response payload."""
+
+    query: AdsQuery
+    count: int
+    results: List[NormalisedAd]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+httpx==0.27.0
+pytest==8.2.2
+respx==0.20.2

--- a/tests/test_ads.py
+++ b/tests/test_ads.py
@@ -1,0 +1,168 @@
+"""Tests for the Meta ads FastAPI endpoint."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import app
+from meta_client import BASE_URL
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    """Return a test client for the FastAPI app."""
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_get_ads_success(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """Ensure a successful call returns normalised ads."""
+
+    monkeypatch.setenv("META_ADLIB_TOKEN", "test-token")
+    payload = {
+        "data": [
+            {
+                "page_name": "Acme Corp",
+                "ad_creative_link_titles": ["Big Sale"],
+                "ad_creative_bodies": ["Buy now"],
+                "ad_snapshot_url": "https://example.com/snapshot",
+                "ad_delivery_start_time": "2024-05-01T00:00:00+0000",
+                "ad_delivery_stop_time": None,
+                "ad_creation_time": "2024-05-01T00:00:00+0000",
+                "publisher_platforms": ["facebook"],
+            }
+        ],
+        "paging": {},
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BASE_URL, params__contains={"search_terms": "finance"}).respond(200, json=payload)
+        response = client.get("/ads", params={"industry": "finance"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["results"][0]["source"] == "meta"
+    assert body["results"][0]["status"] == "active"
+    assert body["results"][0]["advertiser"] == "Acme Corp"
+
+
+def test_get_ads_invalid_params(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """Invalid query params should trigger a 422 error."""
+
+    monkeypatch.setenv("META_ADLIB_TOKEN", "test-token")
+    response = client.get("/ads", params={"industry": "a"})
+    assert response.status_code == 422
+
+    response = client.get("/ads", params={"industry": "finance", "country": "GBR"})
+    assert response.status_code == 422
+
+
+def test_get_ads_missing_token(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """If the env var is missing, return an informative 500."""
+
+    monkeypatch.delenv("META_ADLIB_TOKEN", raising=False)
+    response = client.get("/ads", params={"industry": "finance"})
+    assert response.status_code == 500
+    assert response.json() == {"error": "META_ADLIB_TOKEN not set"}
+
+
+def test_get_ads_upstream_error(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """A Meta API error should surface as a 502."""
+
+    monkeypatch.setenv("META_ADLIB_TOKEN", "test-token")
+    error_payload = {"error": {"code": 190, "message": "Token expired"}}
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BASE_URL, params__contains={"search_terms": "finance"}).respond(400, json=error_payload)
+        response = client.get("/ads", params={"industry": "finance"})
+
+    assert response.status_code == 502
+    assert response.json() == {"error": {"code": 190, "message": "Token expired"}}
+
+
+def test_get_ads_timeout(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """Timeouts should map to a 504 response."""
+
+    monkeypatch.setenv("META_ADLIB_TOKEN", "test-token")
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BASE_URL, params__contains={"search_terms": "finance"}).mock(
+            side_effect=httpx.ReadTimeout("Timeout")
+        )
+        response = client.get("/ads", params={"industry": "finance"})
+
+    assert response.status_code == 504
+    assert response.json() == {"error": "Upstream timeout"}
+
+
+def test_get_ads_pagination(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    """Pagination should continue until the requested limit is met."""
+
+    monkeypatch.setenv("META_ADLIB_TOKEN", "test-token")
+    next_url = f"{BASE_URL}?after=token"
+    first_page = {
+        "data": [
+            {
+                "page_name": "Page A",
+                "ad_creative_link_titles": ["Title A"],
+                "ad_creative_bodies": ["Body A"],
+                "ad_snapshot_url": "https://example.com/a",
+                "ad_delivery_start_time": "2024-05-01T00:00:00+0000",
+                "ad_delivery_stop_time": "2024-05-04T00:00:00+0000",
+                "ad_creation_time": "2024-05-01T00:00:00+0000",
+            },
+            {
+                "page_name": "Page B",
+                "ad_creative_link_titles": ["Title B"],
+                "ad_creative_bodies": ["Body B"],
+                "ad_snapshot_url": "https://example.com/b",
+                "ad_delivery_start_time": "2024-05-02T00:00:00+0000",
+                "ad_delivery_stop_time": None,
+                "ad_creation_time": "2024-05-02T00:00:00+0000",
+            },
+        ],
+        "paging": {"next": next_url},
+    }
+    second_page = {
+        "data": [
+            {
+                "page_name": "Page C",
+                "ad_creative_link_titles": ["Title C"],
+                "ad_creative_bodies": ["Body C"],
+                "ad_snapshot_url": "https://example.com/c",
+                "ad_delivery_start_time": "2024-05-03T00:00:00+0000",
+                "ad_delivery_stop_time": "2024-05-05T00:00:00+0000",
+                "ad_creation_time": "2024-05-03T00:00:00+0000",
+            },
+            {
+                "page_name": "Page D",
+                "ad_creative_link_titles": ["Title D"],
+                "ad_creative_bodies": ["Body D"],
+                "ad_snapshot_url": "https://example.com/d",
+                "ad_delivery_start_time": "2024-05-04T00:00:00+0000",
+                "ad_delivery_stop_time": None,
+                "ad_creation_time": "2024-05-04T00:00:00+0000",
+            },
+        ],
+        "paging": {},
+    }
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(BASE_URL, params__contains={"search_terms": "tech"}).respond(200, json=first_page)
+        router.get(next_url).respond(200, json=second_page)
+        response = client.get("/ads", params={"industry": "tech", "limit": 3})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 3
+    titles = [item["title"] for item in body["results"]]
+    assert titles == ["Title C", "Title A", "Title B"]


### PR DESCRIPTION
## Summary
- add a FastAPI application exposing `/ads` with validated query parameters and structured errors
- implement a Meta Ad Library client with pagination, rate limiting, normalisation, and timeout handling
- add unit tests, dependency list, and VS Code REST examples for manual verification

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ccbb924654832db6adcd6f6cea600f