### PR TITLE
Chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
## What this does
Adds a `.gitattributes` file to enforce LF line endings across the repository.

## Why
Windows clones were converting files to CRLF, causing files to appear as modified in `git status` even with no real content changes. This creates noise in PRs and makes diffs harder to review.

## Changes
- `.gitattributes` added only

## Confirms
- No app logic changed
- No Phase 4 code added
- No schema, seed, UI, or API changes
- No existing files edited