### PR TITLE
Phase 3.5: Add conversion-led ad scoring layout

### DIFF
--- a/app/ads/[id]/page.tsx
+++ b/app/ads/[id]/page.tsx
@@ -2,56 +2,65 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getAdById } from '@/lib/queries/ads';
 
-function parseJsonArray(value: string | null | undefined): string[] {
-  if (!value) return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string') : [];
-  } catch {
-    return [];
-  }
-}
+// ------------------------------------------------------------------ helpers
 
-function parseJsonObject(value: string | null | undefined): Record<string, unknown> | null {
+function parseJson<T>(value: string | null | undefined): T | null {
   if (!value) return null;
   try {
-    const parsed = JSON.parse(value);
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
+    return JSON.parse(value) as T;
   } catch {
     return null;
   }
 }
 
-const SUB_SCORE_LABELS: Record<string, string> = {
-  hookStopScroll: 'Hook / stop-scroll',
-  audienceRelevance: 'Audience relevance',
-  valueClarity: 'Value clarity',
-  trustProofStrength: 'Trust / proof strength',
-  ctaClarity: 'CTA clarity',
-  visualHierarchy: 'Visual hierarchy',
-  productClarity: 'Product clarity',
-  offerClarity: 'Offer clarity',
-  headlineStrength: 'Headline strength',
-  descriptionUsefulness: 'Description usefulness',
-  ctaVisibility: 'CTA visibility',
-  trustSignals: 'Trust signals',
-  firstThreeSeconds: 'First three seconds',
-  soundOffDesign: 'Sound-off design',
-  soundOnEnhancement: 'Sound-on enhancement',
-  onScreenText: 'On-screen text',
-  storyFlow: 'Story flow',
-  authenticity: 'Authenticity',
-  platformNativeFeel: 'Platform-native feel',
+function fmt(score: number | null | undefined): string {
+  if (score === null || score === undefined) return 'N/A';
+  return score.toFixed(1);
+}
+
+const TRIGGER_ORDER: Record<string, number> = {
+  STRONG: 0,
+  MODERATE: 1,
+  WEAK: 2,
+  MISSING: 3,
 };
 
-const AIDA_LABELS: Record<string, string> = {
-  attention: 'Attention',
-  interest: 'Interest',
-  desire: 'Desire',
-  action: 'Action',
+function triggerBadge(strength: string): string {
+  if (strength === 'STRONG') return '● Strong';
+  if (strength === 'MODERATE') return '◑ Moderate';
+  if (strength === 'WEAK') return '○ Weak';
+  return '— Missing';
+}
+
+const VERDICT_LABELS: Record<string, string> = {
+  STRONG_READY_TO_TEST: '✅ Strong — ready to test',
+  GOOD_NEEDS_SHARPENING: '🟡 Good concept — needs sharpening',
+  CLEAR_IDEA_WEAK_SIGNALS: '🟠 Clear idea — weak conversion signals',
+  TOO_VAGUE_MAJOR_REWORK: '🔴 Too vague — needs major rework',
+  INSUFFICIENT_INFORMATION: '⚪ Insufficient information to judge fully',
 };
+
+const TRUST_FUNNEL_LABELS: Record<string, string> = {
+  UNAWARE: 'Unaware — audience does not yet know they have a problem',
+  PROBLEM_AWARE: 'Problem Aware — audience knows the problem, not the solution',
+  SOLUTION_AWARE: 'Solution Aware — audience knows solutions exist, comparing options',
+  PRODUCT_AWARE: 'Product Aware — audience knows this product, needs a reason to act',
+  READY_TO_BUY: 'Ready to Buy — audience needs a nudge, not more information',
+};
+
+// ------------------------------------------------------------------ types
+type Trigger = { name: string; strength: string };
+type AidaExplanations = { attention: string; interest: string; desire: string; action: string };
+type Recommendations = {
+  copy: string;
+  headline: string;
+  description: string;
+  creative: string;
+  conversionStrength: string;
+};
+type RewriteDirection = { hook: string; body: string; cta: string; creativeDirection: string };
+
+// ------------------------------------------------------------------ page
 
 export default async function AdDetailPage({
   params,
@@ -64,156 +73,320 @@ export default async function AdDetailPage({
     notFound();
   }
 
-  const improvements = parseJsonArray(ad.analysis?.improvementsJson);
-  const strengths = parseJsonArray(ad.analysis?.strengthsJson);
-  const weaknesses = parseJsonArray(ad.analysis?.weaknessesJson);
-  const rubricScores = parseJsonObject(ad.analysis?.rubricScoresJson);
-  const aidaMapping = parseJsonObject(ad.analysis?.aidaJson);
+  const a = ad.analysis;
+
+  const recommendations = parseJson<Recommendations>(a?.recommendationsJson ?? null);
+  const rewriteDirection = parseJson<RewriteDirection>(a?.rewriteDirectionJson ?? null);
+  const triggers = (parseJson<Trigger[]>(a?.behaviouralTriggersJson ?? null) ?? [])
+    .sort((x, y) => (TRIGGER_ORDER[x.strength] ?? 4) - (TRIGGER_ORDER[y.strength] ?? 4));
+
+  const strengths = parseJson<string[]>(a?.strengthsJson ?? null) ?? [];
+  const weaknesses = parseJson<string[]>(a?.weaknessesJson ?? null) ?? [];
+
+  const copyScore = a?.copyScore ?? null;
+  const headlineScore = a?.headlineScore ?? null;
+  const descriptionScore = a?.descriptionScore ?? null;
+  const creativeScore = a?.creativeScore ?? null;
+  const clarityScore = a?.clarityScore ?? null;
+  const connectionScore = a?.connectionScore ?? null;
+  const convictionScore = a?.convictionScore ?? null;
+  const combined =
+    clarityScore !== null && connectionScore !== null && convictionScore !== null
+      ? clarityScore + connectionScore + convictionScore
+      : null;
+
+  const aidaAvg =
+    a?.aidaAttentionScore != null &&
+    a?.aidaInterestScore != null &&
+    a?.aidaDesireScore != null &&
+    a?.aidaActionScore != null
+      ? (a.aidaAttentionScore + a.aidaInterestScore + a.aidaDesireScore + a.aidaActionScore) / 4
+      : null;
+
+  // AIDA explanations stored in aidaJson (backwards compatible)
+  const aidaText = parseJson<AidaExplanations>(a?.aidaJson ?? null);
 
   return (
     <section>
       <p>
-        <Link href="/">Back to homepage</Link>
+        <Link href="/">← Back to dashboard</Link>
         {' | '}
-        <Link href="/industries">View industries</Link>
+        <Link href="/industries">Industries</Link>
+        {' | '}
+        <Link href="/competitors">Competitors</Link>
       </p>
 
-      <h1>Ad detail</h1>
-
+      {/* ── Overview ── */}
       <div className="card">
-        <h2>Overview</h2>
-        <p>
-          <strong>Industry:</strong> {ad.industry.name}
-        </p>
-        <p>
-          <strong>Client:</strong> {ad.client.name}
-        </p>
-        <p>
-          <strong>Competitor:</strong> {ad.competitor.name}
-        </p>
-        <p>
-          <strong>Product:</strong> {ad.productOrService ?? 'No product name available'}
-        </p>
-        <p>
-          <strong>Format:</strong> {ad.adFormat}
-        </p>
-        <p>
-          <strong>Score:</strong> {ad.score.toFixed(1)} / 10
-        </p>
-        {ad.analysis?.funnelStage && (
-          <p>
-            <strong>Funnel stage:</strong> {ad.analysis.funnelStage}
-          </p>
-        )}
-        {ad.analysis?.raceStage && (
-          <p>
-            <strong>RACE stage:</strong> {ad.analysis.raceStage}
-          </p>
-        )}
-        <p>
-          <strong>Headline:</strong> {ad.headline ?? 'No headline available'}
-        </p>
-        <p>
-          <strong>Description:</strong> {ad.description ?? 'No description available'}
-        </p>
-        <p>
-          <strong>Primary copy:</strong> {ad.primaryCopy ?? 'No primary copy available'}
-        </p>
+        <h1>Ad detail</h1>
+        <p><strong>Industry:</strong> {ad.industry.name}</p>
+        <p><strong>Client:</strong> {ad.client.name}</p>
+        <p><strong>Competitor:</strong> {ad.competitor.name}</p>
+        <p><strong>Product / service:</strong> {ad.productOrService ?? 'Not specified'}</p>
+        <p><strong>Format:</strong> {ad.adFormat}</p>
+        <p><strong>Overall conversion score:</strong> {ad.score.toFixed(1)} / 10</p>
         <p>
           <strong>Facebook ad link:</strong>{' '}
-          <a href={ad.adLink} target="_blank" rel="noreferrer">
-            Open Facebook ad
-          </a>
+          <a href={ad.adLink} target="_blank" rel="noreferrer">Open ad</a>
         </p>
       </div>
 
-      {aidaMapping && (
+      {/* ── 1. Copy ── */}
+      <div className="card">
+        <h2>1. Copy</h2>
+        <p>
+          <strong>
+            {copyScore !== null
+              ? `Copy Score: ${copyScore.toFixed(1)} / 10`
+              : 'Copy Score: not yet scored'}
+          </strong>
+        </p>
+        {ad.primaryCopy && <p><em>&ldquo;{ad.primaryCopy}&rdquo;</em></p>}
+        <p>{a?.copyAnalysis ?? 'No copy analysis available.'}</p>
+        {strengths.length > 0 && (
+          <>
+            <p><strong>What is working:</strong></p>
+            <ul>{strengths.map((s, i) => <li key={i}>{s}</li>)}</ul>
+          </>
+        )}
+        {weaknesses.length > 0 && (
+          <>
+            <p><strong>What is missing:</strong></p>
+            <ul>{weaknesses.map((w, i) => <li key={i}>{w}</li>)}</ul>
+          </>
+        )}
+      </div>
+
+      {/* ── 2. Headline ── */}
+      <div className="card">
+        <h2>2. Headline</h2>
+        {ad.headline ? (
+          <>
+            <p>
+              <strong>
+                {headlineScore !== null
+                  ? `Headline Score: ${headlineScore.toFixed(1)} / 10`
+                  : 'Headline Score: not yet scored'}
+              </strong>
+            </p>
+            <p><em>&ldquo;{ad.headline}&rdquo;</em></p>
+            <p>{a?.headlineAnalysis ?? 'No headline analysis available.'}</p>
+          </>
+        ) : (
+          <p>Headline not provided. No score assigned.</p>
+        )}
+      </div>
+
+      {/* ── 3. Description ── */}
+      <div className="card">
+        <h2>3. Description</h2>
+        {ad.description ? (
+          <>
+            <p>
+              <strong>
+                {descriptionScore !== null
+                  ? `Description Score: ${descriptionScore.toFixed(1)} / 10`
+                  : 'Description Score: not yet scored'}
+              </strong>
+            </p>
+            <p><em>&ldquo;{ad.description}&rdquo;</em></p>
+            <p>{a?.descriptionAnalysis ?? 'No description analysis available.'}</p>
+          </>
+        ) : (
+          <p>Description not provided. No score assigned.</p>
+        )}
+      </div>
+
+      {/* ── 4. Creative ── */}
+      <div className="card">
+        <h2>4. Creative</h2>
+        <p>
+          <strong>
+            {creativeScore !== null
+              ? `Creative Score: ${creativeScore.toFixed(1)} / 10`
+              : 'Creative Score: not yet scored'}
+          </strong>
+        </p>
+        <p>{a?.creativeAnalysis ?? 'No creative analysis available.'}</p>
+      </div>
+
+      {/* ── 5. AIDA Breakdown ── */}
+      <div className="card">
+        <h2>5. AIDA Breakdown</h2>
+        <p>
+          <strong>Attention:</strong> {fmt(a?.aidaAttentionScore)} / 10
+          {aidaText?.attention ? ` — ${aidaText.attention}` : ''}
+        </p>
+        <p>
+          <strong>Interest:</strong> {fmt(a?.aidaInterestScore)} / 10
+          {aidaText?.interest ? ` — ${aidaText.interest}` : ''}
+        </p>
+        <p>
+          <strong>Desire:</strong> {fmt(a?.aidaDesireScore)} / 10
+          {aidaText?.desire ? ` — ${aidaText.desire}` : ''}
+        </p>
+        <p>
+          <strong>Action:</strong> {fmt(a?.aidaActionScore)} / 10
+          {aidaText?.action ? ` — ${aidaText.action}` : ''}
+        </p>
+      </div>
+
+      {/* ── 6. Clarity, Connection, Conviction ── */}
+      <div className="card">
+        <h2>6. Clarity, Connection, Conviction</h2>
+        <p><strong>Clarity Score:</strong> {fmt(clarityScore)} / 10</p>
+        <p><strong>Connection Score:</strong> {fmt(connectionScore)} / 10</p>
+        <p><strong>Conviction Score:</strong> {fmt(convictionScore)} / 10</p>
+        <p>
+          <strong>Combined Score:</strong>{' '}
+          {combined !== null ? `${combined.toFixed(1)} / 30` : 'Not scored'}
+        </p>
+        <p>
+          {combined !== null
+            ? combined >= 21
+              ? 'Strong across all three dimensions. Ad shows clear conversion readiness.'
+              : combined >= 15
+                ? 'Moderate overall. At least one dimension is limiting conversion effectiveness.'
+                : 'Weak across one or more dimensions. Significant room to improve before testing.'
+            : 'Scores not yet available.'}
+        </p>
+      </div>
+
+      {/* ── 7. Funnel and Framework Mapping ── */}
+      <div className="card">
+        <h2>7. Funnel and Framework Mapping</h2>
+        {a?.funnelStage && (
+          <p>
+            <strong>Funnel stage:</strong> {a.funnelStage}
+            {a.funnelStage === 'TOFU' && ' — Awareness stage. Reaching cold audiences who may not yet know the brand.'}
+            {a.funnelStage === 'MOFU' && ' — Consideration stage. Targeting audiences comparing options or exploring solutions.'}
+            {a.funnelStage === 'BOFU' && ' — Conversion stage. Pushing warm audiences toward a direct action.'}
+          </p>
+        )}
+        {a?.raceStage && (
+          <p>
+            <strong>RACE stage:</strong> {a.raceStage}
+            {a.raceStage === 'REACH' && ' — Building awareness with new audiences.'}
+            {a.raceStage === 'ACT' && ' — Encouraging interaction and consideration.'}
+            {a.raceStage === 'CONVERT' && ' — Driving direct conversion actions.'}
+            {a.raceStage === 'ENGAGE' && ' — Retaining and re-engaging existing audiences.'}
+          </p>
+        )}
+        {a?.trustFunnelStage && (
+          <p>
+            <strong>Trust Funnel stage:</strong>{' '}
+            {TRUST_FUNNEL_LABELS[a.trustFunnelStage] ?? a.trustFunnelStage}
+          </p>
+        )}
+      </div>
+
+      {/* ── 8. Behavioural Trigger Analysis ── */}
+      <div className="card">
+        <h2>8. Behavioural Trigger Analysis</h2>
+        {triggers.filter((t) => t.strength !== 'MISSING').length > 0 ? (
+          <>
+            <p><strong>Triggers detected:</strong></p>
+            <ul>
+              {triggers
+                .filter((t) => t.strength !== 'MISSING')
+                .map((t, i) => (
+                  <li key={i}>
+                    <strong>{t.name}:</strong> {triggerBadge(t.strength)}
+                  </li>
+                ))}
+            </ul>
+          </>
+        ) : (
+          <p>No behavioural triggers detected from available signals.</p>
+        )}
+        {triggers.filter((t) => t.strength === 'MISSING').length > 0 && (
+          <>
+            <p><strong>Triggers not present:</strong></p>
+            <ul>
+              {triggers
+                .filter((t) => t.strength === 'MISSING')
+                .map((t, i) => <li key={i}>{t.name}</li>)}
+            </ul>
+          </>
+        )}
+      </div>
+
+      {/* ── 9. Recommendations for Improvement ── */}
+      <div className="card">
+        <h2>9. Recommendations for Improvement</h2>
+        {recommendations ? (
+          <>
+            <p><strong>To improve copy to 10/10:</strong></p>
+            <p>{recommendations.copy}</p>
+            <p><strong>To improve headline to 10/10:</strong></p>
+            <p>{recommendations.headline}</p>
+            <p><strong>To improve description to 10/10:</strong></p>
+            <p>{recommendations.description}</p>
+            <p><strong>To improve creative to 10/10:</strong></p>
+            <p>{recommendations.creative}</p>
+            <p><strong>To improve conversion strength to 10/10:</strong></p>
+            <p>{recommendations.conversionStrength}</p>
+          </>
+        ) : (
+          <p>Recommendations not yet available. Re-run seed to populate.</p>
+        )}
+      </div>
+
+      {/* ── 10. Rewrite Direction (only shown if any score < 7) ── */}
+      {rewriteDirection && (
         <div className="card">
-          <h2>AIDA Framework</h2>
-          {Object.entries(AIDA_LABELS).map(([key, label]) => {
-            const value = aidaMapping[key];
-            if (!value || typeof value !== 'string') return null;
-            return (
-              <p key={key}>
-                <strong>{label}:</strong> {value}
-              </p>
-            );
-          })}
+          <h2>10. Rewrite Direction</h2>
+          <p><strong>Hook:</strong> {rewriteDirection.hook}</p>
+          <p><strong>Body copy direction:</strong> {rewriteDirection.body}</p>
+          <p><strong>CTA:</strong> {rewriteDirection.cta}</p>
+          <p><strong>Creative direction:</strong> {rewriteDirection.creativeDirection}</p>
         </div>
       )}
 
-      {rubricScores && Object.keys(rubricScores).length > 0 && (
-        <div className="card">
-          <h2>Sub-scores</h2>
-          {Object.entries(rubricScores).map(([key, value]) => {
-            if (value === null || value === undefined) return null;
-            const label = SUB_SCORE_LABELS[key] ?? key;
-            return (
-              <p key={key}>
-                <strong>{label}:</strong> {typeof value === 'number' ? value.toFixed(1) : String(value)} / 10
-              </p>
-            );
-          })}
-        </div>
-      )}
-
+      {/* ── 11. Final Scoring Summary ── */}
       <div className="card">
-        <h2>Creative Analysis</h2>
-        <p>{ad.analysis?.creativeAnalysis ?? 'No creative analysis available.'}</p>
-      </div>
-
-      <div className="card">
-        <h2>Copy Analysis</h2>
-        <p>{ad.analysis?.copyAnalysis ?? 'No copy analysis available.'}</p>
-      </div>
-
-      <div className="card">
-        <h2>Headline Analysis</h2>
-        <p>{ad.analysis?.headlineAnalysis ?? 'No headline analysis available.'}</p>
-      </div>
-
-      <div className="card">
-        <h2>Description Analysis</h2>
-        <p>{ad.analysis?.descriptionAnalysis ?? 'No description analysis available.'}</p>
-      </div>
-
-      <div className="card">
-        <h2>Strengths</h2>
-        {strengths.length === 0 ? (
-          <p>No strengths available.</p>
-        ) : (
-          <ul>
-            {strengths.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <div className="card">
-        <h2>Weaknesses</h2>
-        {weaknesses.length === 0 ? (
-          <p>No weaknesses available.</p>
-        ) : (
-          <ul>
-            {weaknesses.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <div className="card">
-        <h2>Improvements</h2>
-        {improvements.length === 0 ? (
-          <p>No improvements available.</p>
-        ) : (
-          <ul>
-            {improvements.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </ul>
-        )}
+        <h2>11. Final Scoring Summary</h2>
+        <p>
+          <strong>Copy Score:</strong>{' '}
+          {copyScore !== null ? `${copyScore.toFixed(1)} / 10` : 'Not scored'}
+        </p>
+        <p>
+          <strong>Headline Score:</strong>{' '}
+          {ad.headline
+            ? headlineScore !== null
+              ? `${headlineScore.toFixed(1)} / 10`
+              : 'Not scored'
+            : 'Not provided'}
+        </p>
+        <p>
+          <strong>Description Score:</strong>{' '}
+          {ad.description
+            ? descriptionScore !== null
+              ? `${descriptionScore.toFixed(1)} / 10`
+              : 'Not scored'
+            : 'Not provided'}
+        </p>
+        <p>
+          <strong>Creative Score:</strong>{' '}
+          {creativeScore !== null ? `${creativeScore.toFixed(1)} / 10` : 'Not scored'}
+        </p>
+        <p>
+          <strong>AIDA Average:</strong>{' '}
+          {aidaAvg !== null ? `${aidaAvg.toFixed(1)} / 10` : 'Not scored'}
+        </p>
+        <p>
+          <strong>Clarity + Connection + Conviction:</strong>{' '}
+          {combined !== null ? `${combined.toFixed(1)} / 30` : 'Not scored'}
+        </p>
+        <p>
+          <strong>Overall Conversion Potential:</strong> {ad.score.toFixed(1)} / 10
+        </p>
+        <p>
+          <strong>Final verdict:</strong>{' '}
+          {a?.finalVerdict
+            ? VERDICT_LABELS[a.finalVerdict] ?? a.finalVerdict
+            : 'Not yet assessed'}
+        </p>
       </div>
     </section>
   );

--- a/lib/analysis/scoring.ts
+++ b/lib/analysis/scoring.ts
@@ -1,4 +1,14 @@
-import type { FunnelStage, RaceStage } from '@/lib/analysis/types';
+import type {
+  AidaScores,
+  BehaviouralTrigger,
+  FinalVerdict,
+  FunnelStage,
+  RaceStage,
+  Recommendations,
+  RewriteDirection,
+  TriggerStrength,
+  TrustFunnelStage,
+} from '@/lib/analysis/types';
 
 export const QUALIFICATION_SCORE = 7.0;
 
@@ -6,17 +16,15 @@ export function clampScore(value: number): number {
   return Number(Math.max(0, Math.min(10, value)).toFixed(2));
 }
 
+// --- Kept for backwards compatibility with SubScores generation ---
+// Base reduced from 6.0 to 4.0 to prevent inflation. Increment adjusted.
 export function scoreBySignals(
   text: string,
   positiveSignals: RegExp[],
-  base = 6.0,
-  increment = 0.9,
+  base = 4.0,
+  increment = 1.2,
 ): number {
   let score = base;
-
-  if (text.length > 120) {
-    score += 0.4;
-  }
 
   for (const signal of positiveSignals) {
     if (signal.test(text)) {
@@ -27,6 +35,17 @@ export function scoreBySignals(
   return clampScore(score);
 }
 
+export function deriveOverallScore(scores: number[]): number {
+  if (scores.length === 0) return 0;
+  const sum = scores.reduce((total, value) => total + value, 0);
+  return clampScore(sum / scores.length);
+}
+
+export function qualifies(score: number): boolean {
+  return score >= QUALIFICATION_SCORE;
+}
+
+// --- Framework mapping (backwards compatible) ---
 export function mapFunnelStage(copy: string): FunnelStage {
   if (/buy|book|start now|register|trial|sign up|enrol/i.test(copy)) return 'BOFU';
   if (/learn|discover|compare|why|how/i.test(copy)) return 'MOFU';
@@ -40,12 +59,476 @@ export function mapRaceStage(copy: string): RaceStage {
   return 'REACH';
 }
 
-export function deriveOverallScore(scores: number[]): number {
-  if (scores.length === 0) return 0;
-  const sum = scores.reduce((total, value) => total + value, 0);
-  return clampScore(sum / scores.length);
+// --- Phase 3.5: Conversion-focused scoring helpers ---
+
+/**
+ * Extracts numeric AIDA scores from human-written analysis text.
+ * Looks for patterns like "Attention 9.2/10", "Interest 9/10", "Desire 9.3/10", "Action 8.5/10".
+ * Returns null if all four scores cannot be reliably extracted.
+ * These are the human analyst's own ratings — authoritative evidence.
+ */
+export function extractAnalysisAidaScores(analysisNotes: string): AidaScores | null {
+  if (!analysisNotes || analysisNotes.trim().length < 20) return null;
+
+  const extract = (label: string): number | null => {
+    const pattern = new RegExp(`${label}\\s+(\\d+(?:\\.\\d+)?)\\s*/\\s*10`, 'i');
+    const match = analysisNotes.match(pattern);
+    if (match) return clampScore(parseFloat(match[1]));
+    return null;
+  };
+
+  const attention = extract('Attention');
+  const interest = extract('Interest');
+  const desire = extract('Desire');
+  const action = extract('Action');
+
+  if (attention !== null && interest !== null && desire !== null && action !== null) {
+    return { attention, interest, desire, action };
+  }
+  return null;
 }
 
-export function qualifies(score: number): boolean {
-  return score >= QUALIFICATION_SCORE;
+/**
+ * Scores copy on conversion signals.
+ * Starts at 2.0. Each confirmed signal adds points.
+ * Works with or without human-written analysis notes.
+ */
+export function scoreCopyStrength(copy: string, analysisNotes: string): number {
+  if (!copy || copy.trim().length < 10) return 1.0;
+
+  const all = `${copy} ${analysisNotes}`;
+  let score = 2.0;
+
+  // Hook clarity
+  if (/\?|stop|imagine|what if|you're|are you|tired|struggling|finally|instantly|immediately|irresistible/i.test(copy)) score += 0.7;
+
+  // Audience specificity
+  if (/for\s+(business|owner|manager|parent|marketer|brand|team|women|men|anyone who|company|companies|enterprise|startup|founder|creator|seller)/i.test(all) ||
+      /if you|when you|you (want|need|have|feel|are)/i.test(copy)) score += 0.7;
+
+  // Pain-point sharpness
+  if (/problem|struggle|frustrat|fail|waste|miss|overwhelm|stress|pain|challeng/i.test(all)) score += 0.7;
+
+  // Benefit clarity — specific, tangible outcome
+  if (/save|increase|grow|boost|reduce|improve|get more|earn|double|results in|scale|expand|generate|convert|revenue|optimis|optimiz/i.test(all)) score += 0.7;
+
+  // Offer clarity
+  if (/free|trial|discount|% off|limited|bonus|includ|guarantee|no risk/i.test(all)) score += 0.6;
+
+  // Proof or social evidence
+  if (/\d+[\w\s]*(client|customer|brand|business|user|review|result|company|companies)|trusted|award|certified|case study|testimonial|Fortune|fortune 100|fortune 500|leader|leading|authority|industry/i.test(all)) score += 0.7;
+
+  // Urgency or scarcity
+  if (/today|now|limited|expir|last chance|only \d+|deadline|before/i.test(all)) score += 0.5;
+
+  // CTA strength — specific action
+  if (/book|start|get started|sign up|try|claim|register|shop now|learn more|download|apply/i.test(copy)) score += 0.7;
+
+  // Objection handling
+  if (/no (contract|commitment|risk|credit card)|cancel anytime|money.back|guaranteed/i.test(all)) score += 0.5;
+
+  // Emotional pull
+  if (/feel|transform|confidence|proud|peace|freedom|joy|excited|relief|imagine/i.test(copy)) score += 0.4;
+
+  return clampScore(score);
+}
+
+/**
+ * Scores headline on conversion intent.
+ * Returns null if no headline is provided.
+ */
+export function scoreHeadlineStrength(headline: string | undefined): number | null {
+  if (!headline || headline.trim().length < 3) return null;
+
+  let score = 2.0;
+
+  // Length sweet spot
+  if (headline.length > 15 && headline.length < 100) score += 0.8;
+
+  // Pain or desire hook
+  if (/\?|stop|tired|finally|how to|why|secret|proven|the truth/i.test(headline)) score += 1.0;
+
+  // Offer or outcome stated
+  if (/save|get|boost|grow|earn|free|results|more|faster|better|smarter|scale|revenue/i.test(headline)) score += 1.0;
+
+  // Specificity with numbers or named outcomes
+  if (/\d+%|\d+x|\d+\s*(day|week|month|hour)|step|way/i.test(headline)) score += 0.8;
+
+  // Conversion intent
+  if (/start|try|book|claim|discover|learn|find out|see how/i.test(headline)) score += 0.8;
+
+  // Audience relevance
+  if (/you|your|for (business|team|brand|owner|parent|marketer|company|enterprise)/i.test(headline)) score += 0.6;
+
+  return clampScore(score);
+}
+
+/**
+ * Scores description on conversion support.
+ * Returns null if no description is provided.
+ */
+export function scoreDescriptionStrength(description: string | undefined): number | null {
+  if (!description || description.trim().length < 3) return null;
+
+  let score = 2.0;
+
+  // Adds benefit or detail beyond the headline
+  if (description.length > 20) score += 0.6;
+
+  // Proof or trust element
+  if (/testimonial|review|trusted|\d+[\w\s]*(client|customer)|guarantee|certif/i.test(description)) score += 1.2;
+
+  // Urgency or scarcity reinforcement
+  if (/limited|today|now|expir|last chance|only/i.test(description)) score += 0.8;
+
+  // Risk reducer
+  if (/no (risk|commitment|contract)|cancel|money.back|free trial/i.test(description)) score += 1.0;
+
+  // CTA support
+  if (/click|tap|swipe|book|start|learn|get|apply/i.test(description)) score += 0.8;
+
+  // Funnel-stage reinforcement
+  if (/why|how|what you get|here.s what|includes/i.test(description)) score += 0.6;
+
+  return clampScore(score);
+}
+
+/**
+ * Scores creative on conversion signals from creative analysis text.
+ * Falls back to analysisNotes when creativeAnalysis is absent — common when
+ * Creative Analysis CSV column is empty but Analysis column has rich content.
+ */
+export function scoreCreativeStrength(
+  creativeAnalysis: string,
+  format: 'STATIC' | 'VIDEO',
+  analysisNotes = '',
+): number {
+  // Use creativeAnalysis if present; fall back to analysisNotes
+  const source = (creativeAnalysis && creativeAnalysis.trim().length >= 10)
+    ? creativeAnalysis
+    : analysisNotes;
+
+  if (!source || source.trim().length < 10) return 2.5;
+
+  const text = source.toLowerCase();
+  let score = 2.0;
+
+  // First-frame / stopping power
+  if (/hook|stop.scroll|first.frame|attention|bold|striking|pattern interrupt|opening|commands|instantly|immediately|pop/i.test(text)) score += 0.7;
+
+  // Visual clarity
+  if (/clear|clean|simple|readable|legible|contrast|hierarchy|focal point|minimalist|polished|crisp|sharp/i.test(text)) score += 0.6;
+
+  // Message-creative alignment
+  if (/align|consistent|reinforce|support|match|reflect/i.test(text)) score += 0.6;
+
+  // Audience recognition
+  if (/relatable|recogni|audience|resonate|speak to|persona|target|engaging|vibrant|dynamic/i.test(text)) score += 0.6;
+
+  // Emotional trigger in creative
+  if (/emotion|feel|warm|trust|fear|excite|aspir|desire|transform|joy|laughter|authentic|genuine/i.test(text)) score += 0.6;
+
+  // Proof and trust signals visible
+  if (/logo|badge|testimonial|before.after|result|rating|proof|certif|social proof/i.test(text)) score += 0.7;
+
+  // Offer visibility
+  if (/offer|price|discount|free|cta|button|value|irresistible/i.test(text)) score += 0.6;
+
+  if (format === 'VIDEO') {
+    if (/reels|stories|ugc|vertical|native|authentic|real person|face|montage|sequence/i.test(text)) score += 0.6;
+    if (/caption|subtitle|text overlay|sound.off|muted|on.screen|text on/i.test(text)) score += 0.6;
+  } else {
+    if (/cta|call to action|button|click|tap|swipe up/i.test(text)) score += 0.6;
+    if (/frictionless|easy|simple|one.click|instant/i.test(text)) score += 0.4;
+  }
+
+  return clampScore(score);
+}
+
+/**
+ * Derives AIDA scores from available ad inputs.
+ * When analysisNotes contains explicit numeric AIDA scores written by a human analyst
+ * (e.g. "Attention 9.2/10"), those scores are returned directly as authoritative evidence.
+ * Otherwise, scores are computed from conversion signal patterns.
+ */
+export function scoreAida(
+  copy: string,
+  headline: string,
+  creativeAnalysis: string,
+  analysisNotes = '',
+): AidaScores {
+  // Use human analyst scores when available — more reliable than regex
+  const extracted = extractAnalysisAidaScores(analysisNotes);
+  if (extracted) return extracted;
+
+  const all = `${copy} ${headline} ${creativeAnalysis} ${analysisNotes}`;
+
+  let attention = 2.0;
+  if (/\?|stop|imagine|finally|you're|are you|tired|hook|bold|striking|first frame|instantly|immediately|commands/i.test(all)) attention += 1.2;
+  if (/pattern interrupt|contrast|unexpected|surprising/i.test(all)) attention += 0.8;
+  if (headline && headline.trim().length > 10) attention += 0.8;
+  if (/visual|creative|image|video|colour|color|design/i.test(all)) attention += 0.7;
+
+  let interest = 2.0;
+  if (/for\s+(business|owner|marketer|parent|brand|team|company|companies|enterprise|startup|founder)/i.test(all)) interest += 1.0;
+  if (/if you|when you/i.test(all)) interest += 0.7;
+  if (/problem|struggle|frustrat|challeng|pain point/i.test(all)) interest += 1.0;
+  if (/product|service|solution|what (we|it) (does|offers|provides)/i.test(all)) interest += 0.8;
+  if (/detail|explain|how it works|what you get/i.test(all)) interest += 0.7;
+
+  let desire = 2.0;
+  if (/save|grow|earn|boost|increase|reduce|improve|results|scale|revenue|generate/i.test(all)) desire += 1.0;
+  if (/testimonial|proof|\d+\s*(client|customer|brand|result)|case study|Fortune|fortune 100|authority|leading/i.test(all)) desire += 1.0;
+  if (/transform|freedom|confidence|peace|imagine|feel|joy|excitement/i.test(all)) desire += 0.7;
+  if (/free|discount|bonus|guarantee|offer|trial/i.test(all)) desire += 0.8;
+
+  let action = 2.0;
+  if (/book|start|get started|sign up|try|claim|register|shop now|download|apply/i.test(all)) action += 1.2;
+  if (/today|now|limited|expir|last chance|before/i.test(all)) action += 0.8;
+  if (/no (risk|commitment|contract)|cancel|money.back|free trial/i.test(all)) action += 0.8;
+  if (/one click|easy|simple|instant|quick/i.test(all)) action += 0.5;
+
+  return {
+    attention: clampScore(attention),
+    interest: clampScore(interest),
+    desire: clampScore(desire),
+    action: clampScore(action),
+  };
+}
+
+/**
+ * Scores Clarity, Connection, and Conviction.
+ * analysisNotes is included so that rich human analysis enriches the signal pool.
+ */
+export function scoreClarityConnectionConviction(
+  copy: string,
+  headline: string,
+  description: string,
+  analysisNotes = '',
+): { clarity: number; connection: number; conviction: number } {
+  const all = `${copy} ${headline} ${description} ${analysisNotes}`;
+
+  let clarity = 2.0;
+  if (copy.trim().length > 30) clarity += 0.8;
+  if (/one (thing|benefit|offer|outcome|step)|simply|clearly|specifically|direct|straightforward|immediate|instantly|obvious|focused|concise|minimalist/i.test(all)) clarity += 0.8;
+  if (headline && headline.trim().length > 10) clarity += 0.8;
+  if (/what (you get|we do|it does|this means)|cta|call to action/i.test(all)) clarity += 0.8;
+
+  let connection = 2.0;
+  if (/you|your/i.test(copy)) connection += 0.8;
+  if (/feel|struggle|tired|frustrated|overwhelm|problem|challenge|emotion|empathy/i.test(all)) connection += 1.0;
+  if (/for (business owner|marketer|parent|team|anyone who|company|companies|enterprise|founder)/i.test(all)) connection += 0.8;
+  if (/we (know|understand|get it)|been there/i.test(all)) connection += 0.8;
+  if (/story|journey|before|after|relatable|resonat|authentic|joy|laughter|fun|experience|community|warm/i.test(all)) connection += 0.6;
+
+  let conviction = 2.0;
+  if (/\d+[\w\s]*(client|customer|brand|result|review)|testimonial|case study|Fortune|fortune 100|authority|leading|trusted by/i.test(all)) conviction += 1.2;
+  if (/guarantee|certif|award|trusted|proven|data|study|strong|excellent|compelling|effective|perfectly|credible|exceptional|superior/i.test(all)) conviction += 1.0;
+  if (/specific result|\d+%|\d+x|in \d+ (day|week|month)/i.test(all)) conviction += 0.8;
+  if (/no (risk|commitment)|money.back|cancel anytime/i.test(all)) conviction += 0.7;
+
+  return {
+    clarity: clampScore(clarity),
+    connection: clampScore(connection),
+    conviction: clampScore(conviction),
+  };
+}
+
+/**
+ * Maps copy signals to Trust Funnel stage.
+ */
+export function mapTrustFunnelStage(copy: string, headline: string): TrustFunnelStage {
+  const all = `${copy} ${headline}`;
+
+  if (/buy now|get started|book|register|claim|checkout|start your|sign up today/i.test(all)) return 'READY_TO_BUY';
+  if (/why (choose|us|this)|compare|vs\.|versus|better than|switch|alternative/i.test(all)) return 'PRODUCT_AWARE';
+  if (/how (to|we|it works)|solution|result|what (you get|we offer)/i.test(all)) return 'SOLUTION_AWARE';
+  if (/problem|struggle|frustrated|tired|challenge|do you feel|are you/i.test(all)) return 'PROBLEM_AWARE';
+  return 'UNAWARE';
+}
+
+/**
+ * Detects behavioural triggers in the ad.
+ * analysisNotes is included so the human analyst's language can surface triggers.
+ */
+export function detectBehaviouralTriggers(
+  copy: string,
+  headline: string,
+  creativeAnalysis: string,
+  analysisNotes = '',
+): BehaviouralTrigger[] {
+  const all = `${copy} ${headline} ${creativeAnalysis} ${analysisNotes}`;
+
+  function strength(pattern: RegExp): TriggerStrength {
+    const matches = (all.match(new RegExp(pattern.source, `g${pattern.flags.replace('g', '')}`)) ?? []).length;
+    if (matches >= 2) return 'STRONG';
+    if (matches === 1) return 'MODERATE';
+    return 'MISSING';
+  }
+
+  return [
+    { name: 'FOMO', strength: strength(/miss out|limited|running out|last chance|only \d+|expir|before it.s gone/i) },
+    { name: 'Urgency', strength: strength(/today|now|deadline|this week|hurry|act fast|limited time/i) },
+    { name: 'Social proof', strength: strength(/\d+[\w\s]*(client|customer|brand|business|review|user)|trusted by|as seen|Fortune|testimonial/i) },
+    { name: 'Authority', strength: strength(/award|certif|expert|proven|industry|leader|accredited|recognised|fortune 100|fortune 500|authority/i) },
+    { name: 'Before and after', strength: strength(/before|after|transform|used to|now (i|we|they)|from .* to/i) },
+    { name: 'Risk reduction', strength: strength(/no (risk|commitment|contract)|money.back|guarantee|cancel anytime|free trial/i) },
+    { name: 'Convenience', strength: strength(/easy|simple|one.click|instant|quick|no hassle|effortless|done for you/i) },
+    { name: 'Value', strength: strength(/save|free|bonus|value|included|worth|\$ off|% off|discount/i) },
+    { name: 'Fear of loss', strength: strength(/lose|losing|miss|fail|falling behind|at risk|don.t let|costly/i) },
+    { name: 'Curiosity', strength: strength(/secret|discover|find out|what (most|nobody)|you didn.t know|surprising/i) },
+    { name: 'Status', strength: strength(/exclusive|elite|premium|top|best|leading|first class|vip|Fortune/i) },
+    { name: 'Belonging', strength: strength(/community|join|together|like.minded|tribe|members|network/i) },
+    { name: 'Relief', strength: strength(/relief|finally|no more|stop (worrying|struggling)|peace of mind|stress.free/i) },
+    { name: 'Instant gratification', strength: strength(/instantly|immediately|right now|in minutes|today|same day/i) },
+    { name: 'Contrast', strength: strength(/vs\.|versus|unlike|compared to|instead of|better than|while others/i) },
+  ];
+}
+
+/**
+ * Derives the final conversion verdict.
+ *
+ * Rules (in evaluation order):
+ * 1. INSUFFICIENT_INFORMATION — both copy AND creative are near-zero (<3.0). Not enough to judge.
+ * 2. TOO_VAGUE_MAJOR_REWORK   — either core signal (copy or creative) is broken (<3.0),
+ *                               OR overall is very weak (<5.5). Ad needs fundamental rebuilding.
+ * 3. STRONG_READY_TO_TEST     — overall ≥8.0 AND every component score ≥7.0.
+ * 4. GOOD_NEEDS_SHARPENING    — overall ≥7.0 and core signals are intact. Qualifiable ad.
+ * 5. CLEAR_IDEA_WEAK_SIGNALS  — overall 5.5–6.99, core signals intact. Concept present,
+ *                               conversion evidence insufficient to qualify.
+ * 6. TOO_VAGUE_MAJOR_REWORK   — fallthrough for overall <5.5 with intact core signals.
+ *
+ * Consistency guarantee: an ad with overallScore ≥7.0 will NEVER receive
+ * TOO_VAGUE_MAJOR_REWORK unless a core signal is broken.
+ */
+export function deriveFinalVerdict(
+  copyScore: number,
+  headlineScore: number | null,
+  descriptionScore: number | null,
+  creativeScore: number,
+  overallScore: number,
+): FinalVerdict {
+  // Rule 1: neither primary signal carries usable information
+  if (copyScore < 3.0 && creativeScore < 3.0) return 'INSUFFICIENT_INFORMATION';
+
+  // Rule 2a: a core signal is fundamentally broken — copy or creative near-zero
+  const coreSignalBroken = copyScore < 3.0 || creativeScore < 3.0;
+  if (coreSignalBroken) return 'TOO_VAGUE_MAJOR_REWORK';
+
+  // From here, both copy and creative are functional (≥3.0)
+  const componentScores = [copyScore, creativeScore];
+  if (headlineScore !== null) componentScores.push(headlineScore);
+  if (descriptionScore !== null) componentScores.push(descriptionScore);
+
+  const allAbove7 = componentScores.every((s) => s >= 7.0);
+
+  // Rule 3: all elements are strong
+  if (overallScore >= 8.0 && allAbove7) return 'STRONG_READY_TO_TEST';
+
+  // Rule 4: overall qualifies — some elements need work but foundation is real
+  if (overallScore >= 7.0) return 'GOOD_NEEDS_SHARPENING';
+
+  // Rule 5: concept is there but conversion evidence falls short of threshold
+  if (overallScore >= 5.5) return 'CLEAR_IDEA_WEAK_SIGNALS';
+
+  // Rule 2b: overall too weak even with functional core signals
+  return 'TOO_VAGUE_MAJOR_REWORK';
+}
+
+/**
+ * Derives per-element recommendations. Specific, not generic.
+ */
+export function deriveRecommendations(
+  copyScore: number,
+  headlineScore: number | null,
+  descriptionScore: number | null,
+  creativeScore: number,
+  improvementNotes: string,
+  creativeImprovementNotes: string,
+): Recommendations {
+  const copyRec =
+    improvementNotes && improvementNotes.trim().length > 10
+      ? improvementNotes
+      : copyScore < 5
+        ? 'Rewrite the hook to open with a sharp pain point or bold outcome statement. Add one specific proof element (number, client count, or named result). End with a single, direct CTA tied to the offer.'
+        : copyScore < 7
+          ? 'Strengthen the hook and add proof. Make the benefit statement more specific with numbers or named outcomes. Ensure the CTA names the exact next step.'
+          : 'Sharpen urgency. Add one objection handler. Test a pain-led vs. outcome-led opening.';
+
+  const headlineRec =
+    headlineScore === null
+      ? 'No headline provided. Add a headline that states the core outcome or pain point in under 10 words.'
+      : headlineScore < 5
+        ? 'The headline lacks clarity and conversion intent. Rewrite to lead with the single most important outcome or pain point. Use numbers or specifics where possible.'
+        : headlineScore < 7
+          ? 'The headline is present but not sharp enough. Test a more specific benefit-led version with a number, a timeframe, or a named outcome.'
+          : 'Headline is working. Test one alternative that leads with a question or named pain to compare engagement rates.';
+
+  const descriptionRec =
+    descriptionScore === null
+      ? 'No description provided. Add 1–2 sentences that reinforce the offer, add proof, or reduce hesitation.'
+      : descriptionScore < 5
+        ? 'Description is weak. Rewrite to add something the headline and copy did not — proof, a risk reducer, or a secondary benefit.'
+        : descriptionScore < 7
+          ? 'Description supports the ad but could be stronger. Add one trust signal or urgency element.'
+          : 'Description is functional. Test adding a specific number or testimonial snippet.';
+
+  const creativeRec =
+    creativeImprovementNotes && creativeImprovementNotes.trim().length > 10
+      ? creativeImprovementNotes
+      : creativeScore < 5
+        ? 'Creative lacks conversion signals. Ensure the first frame communicates the offer immediately. Add visible trust signals and a clear CTA overlay.'
+        : creativeScore < 7
+          ? 'Creative is adequate but not conversion-optimised. Improve visual hierarchy so the offer is dominant. Test a before/after or result-focused visual.'
+          : 'Creative is functional. Test a UGC-style or face-forward variant to compare authenticity against polished creative.';
+
+  return {
+    copy: copyRec,
+    headline: headlineRec,
+    description: descriptionRec,
+    creative: creativeRec,
+    conversionStrength:
+      'To strengthen conversion: (1) Ensure one clear offer is visible in copy and creative. (2) Add a specific proof element. (3) Make the CTA name the exact action and outcome. (4) Reduce friction with a risk reducer. (5) Test urgency against benefit-led framing.',
+  };
+}
+
+/**
+ * Derives rewrite direction when any component score is below 7.
+ * Returns null when all components score >= 7.
+ */
+export function deriveRewriteDirection(
+  copyScore: number,
+  headlineScore: number | null,
+  descriptionScore: number | null,
+  creativeScore: number,
+  copy: string,
+  funnelStage: string,
+): RewriteDirection {
+  const scoresBelow7 = [
+    copyScore < 7,
+    headlineScore !== null && headlineScore < 7,
+    descriptionScore !== null && descriptionScore < 7,
+    creativeScore < 7,
+  ].some(Boolean);
+
+  if (!scoresBelow7) return null;
+
+  const stageLabel =
+    funnelStage === 'BOFU'
+      ? 'bottom-of-funnel (conversion)'
+      : funnelStage === 'MOFU'
+        ? 'middle-of-funnel (consideration)'
+        : 'top-of-funnel (awareness)';
+
+  const hasProof = /\d+[\w\s]*(client|customer)|testimonial|case study|Fortune/i.test(copy);
+  const hasBenefit = /save|grow|earn|boost|increase|results|scale|revenue/i.test(copy);
+  const hasUrgency = /today|now|limited|expir/i.test(copy);
+
+  return {
+    hook: `Open with a sharp, specific pain point or bold outcome for a ${stageLabel} audience. The first line must earn the scroll.`,
+    body: `${hasBenefit ? 'Build on the benefit already present — make it more specific with a number or timeframe.' : 'Add a clear, specific benefit statement with a measurable outcome.'} ${hasProof ? 'Amplify the existing proof with more specificity.' : 'Add at least one proof element: a client count, result, or testimonial snippet.'} ${hasUrgency ? 'Urgency is present — ensure it is tied to a real reason.' : 'Add a time-bound or scarcity-based reason to act now.'}`,
+    cta: `Use a single, direct CTA naming the exact action and outcome. Match the strength to the ${stageLabel} stage.`,
+    creativeDirection:
+      'Ensure the first frame or dominant visual states the core offer or outcome immediately. Add a visible trust signal. If video, ensure it works sound-off. If static, ensure the offer and CTA are dominant visual elements.',
+  };
 }

--- a/lib/analysis/staticAnalyser.ts
+++ b/lib/analysis/staticAnalyser.ts
@@ -1,8 +1,21 @@
 import {
+  clampScore,
   deriveOverallScore,
+  deriveFinalVerdict,
+  deriveRecommendations,
+  deriveRewriteDirection,
+  detectBehaviouralTriggers,
+  extractAnalysisAidaScores,
   mapFunnelStage,
   mapRaceStage,
+  mapTrustFunnelStage,
   qualifies,
+  scoreAida,
+  scoreClarityConnectionConviction,
+  scoreCopyStrength,
+  scoreCreativeStrength,
+  scoreDescriptionStrength,
+  scoreHeadlineStrength,
   scoreBySignals,
 } from '@/lib/analysis/scoring';
 import type { AnalysisOutput, ExampleRow } from '@/lib/analysis/types';
@@ -11,97 +24,205 @@ export function analyseStaticAd(row: ExampleRow): AnalysisOutput {
   const copy = row.Copy ?? '';
   const headline = row.Headline ?? '';
   const description = row.Description ?? '';
-  const analysisReference = `${row.Analysis ?? ''} ${row['Creative Analysis'] ?? ''}`;
-  const allText = `${copy} ${headline} ${description} ${analysisReference}`;
+  const analysisNotes = row.Analysis ?? '';
+  const creativeAnalysisText = row['Creative Analysis'] ?? '';
+  const improvementNotes = row.Improvement ?? '';
+  const creativeImprovementNotes = row['Creative Improvements'] ?? '';
+  const otherFeedbacks = row['Other Feedbacks'] ?? '';
 
+  const allText = `${copy} ${headline} ${description} ${analysisNotes} ${creativeAnalysisText} ${otherFeedbacks}`;
+
+  // --- Phase 3.5: Conversion-focused component scores ---
+  const copyScore = scoreCopyStrength(copy, `${analysisNotes} ${otherFeedbacks}`);
+  const headlineScore = scoreHeadlineStrength(headline || undefined);
+  const descriptionScore = scoreDescriptionStrength(description || undefined);
+
+  // Pass analysisNotes so Creative Analysis fallback uses the rich analysis field
+  const creativeScore = scoreCreativeStrength(creativeAnalysisText, 'STATIC', analysisNotes);
+
+  // Pass analysisNotes so explicit human AIDA scores (e.g. "Attention 9/10") are used when present
+  const aidaScores = scoreAida(copy, headline, creativeAnalysisText, analysisNotes);
+  const aidaAvg = clampScore(
+    (aidaScores.attention + aidaScores.interest + aidaScores.desire + aidaScores.action) / 4,
+  );
+
+  // Pass analysisNotes so rich analysis text informs CCC scoring
+  const { clarity: clarityScore, connection: connectionScore, conviction: convictionScore } =
+    scoreClarityConnectionConviction(copy, headline, description, analysisNotes);
+
+  const trustFunnelStage = mapTrustFunnelStage(copy, headline);
+  const funnelStage = mapFunnelStage(copy);
+  const raceStage = mapRaceStage(copy);
+
+  // Pass analysisNotes so human analyst language surfaces behavioural triggers
+  const behaviouralTriggers = detectBehaviouralTriggers(copy, headline, creativeAnalysisText, analysisNotes);
+
+  const recommendations = deriveRecommendations(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    improvementNotes,
+    creativeImprovementNotes,
+  );
+
+  // --- Overall score ---
+  // When the human analyst has written explicit numeric AIDA scores in their analysis,
+  // those scores are authoritative evidence — weight them 55% vs 45% for pattern scores.
+  // Rationale: a human reviewing the actual ad is more reliable than regex on sparse copy text.
+  const hasAuthorityAida = extractAnalysisAidaScores(analysisNotes) !== null;
+
+  let overallScore: number;
+  if (hasAuthorityAida) {
+    const otherInputs = [copyScore, creativeScore, clarityScore, connectionScore, convictionScore];
+    if (headlineScore !== null) otherInputs.push(headlineScore);
+    if (descriptionScore !== null) otherInputs.push(descriptionScore);
+    const otherAvg = deriveOverallScore(otherInputs);
+    overallScore = clampScore(aidaAvg * 0.55 + otherAvg * 0.45);
+  } else {
+    const scoringInputs = [copyScore, creativeScore, aidaAvg, clarityScore, connectionScore, convictionScore];
+    if (headlineScore !== null) scoringInputs.push(headlineScore);
+    if (descriptionScore !== null) scoringInputs.push(descriptionScore);
+    overallScore = deriveOverallScore(scoringInputs);
+  }
+
+  const rewriteDirection = deriveRewriteDirection(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    copy,
+    funnelStage,
+  );
+
+  const finalVerdict = deriveFinalVerdict(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    overallScore,
+  );
+
+  // --- Backwards-compatible SubScores (kept for existing Prisma fields) ---
   const subScores = {
-    hookStopScroll: scoreBySignals(allText, [
-      /bold|strong|attention|scroll|first/i,
-      /benefit|result|outcome/i,
-    ]),
-    audienceRelevance: scoreBySignals(allText, [
-      /audience|for\s+\w+/i,
-      /business|marketer|owner|customer/i,
-    ]),
-    valueClarity: scoreBySignals(allText, [
-      /benefit|value|save|growth|revenue|improve/i,
-      /clear|simple|easy/i,
-    ]),
-    trustProofStrength: scoreBySignals(allText, [
-      /testimonial|proof|trusted|case study|results/i,
-      /award|certified|guarantee/i,
-    ]),
-    ctaClarity: scoreBySignals(allText, [
-      /book|start|get started|learn more|shop|register/i,
-      /today|now/i,
-    ]),
-    visualHierarchy: scoreBySignals(analysisReference, [
-      /visual|hierarchy|contrast|layout|design/i,
-    ]),
-    productClarity: scoreBySignals(allText, [
-      /product|service|what|solution/i,
-    ]),
-    offerClarity: scoreBySignals(allText, [
-      /offer|free|discount|trial|subsidy/i,
-    ]),
-    headlineStrength: scoreBySignals(headline, [
-      /benefit|result|more|faster|easy|clear/i,
-    ]),
-    descriptionUsefulness: scoreBySignals(description, [
-      /detail|support|context|what you get/i,
-    ]),
-    ctaVisibility: scoreBySignals(allText, [
-      /cta|call to action|book|register|start/i,
-    ]),
-    trustSignals: scoreBySignals(allText, [
-      /proof|testimonial|trust|review|rating/i,
-    ]),
+    hookStopScroll: scoreBySignals(allText, [/bold|strong|attention|scroll|first/i, /benefit|result|outcome/i]),
+    audienceRelevance: scoreBySignals(allText, [/audience|for\s+\w+/i, /business|marketer|owner|customer|company/i]),
+    valueClarity: scoreBySignals(allText, [/benefit|value|save|growth|revenue|improve|scale/i, /clear|simple|easy/i]),
+    trustProofStrength: scoreBySignals(allText, [/testimonial|proof|trusted|case study|results|Fortune/i, /award|certified|guarantee|authority/i]),
+    ctaClarity: scoreBySignals(allText, [/book|start|get started|learn more|shop|register/i, /today|now/i]),
+    visualHierarchy: scoreBySignals(creativeAnalysisText || analysisNotes, [/visual|hierarchy|contrast|layout|design|minimalist/i]),
+    productClarity: scoreBySignals(allText, [/product|service|what|solution/i]),
+    offerClarity: scoreBySignals(allText, [/offer|free|discount|trial|subsidy/i]),
+    headlineStrength: scoreBySignals(headline, [/benefit|result|more|faster|easy|clear/i]),
+    descriptionUsefulness: scoreBySignals(description, [/detail|support|context|what you get/i]),
+    ctaVisibility: scoreBySignals(allText, [/cta|call to action|book|register|start/i]),
+    trustSignals: scoreBySignals(allText, [/proof|testimonial|trust|review|rating|Fortune/i]),
   };
 
-  const overallScore = deriveOverallScore(Object.values(subScores));
+  // --- Narrative analysis fields ---
+  const copyAnalysisText = analysisNotes && analysisNotes.trim().length > 5
+    ? analysisNotes
+    : `Copy scored ${copyScore.toFixed(1)}/10. ${
+        copyScore >= 7
+          ? 'Strong conversion signals detected. Hook, benefit, and CTA are present.'
+          : copyScore >= 5
+            ? 'Moderate signals. Some conversion elements are present but not fully sharpened.'
+            : 'Weak conversion signals. Hook, proof, and CTA need significant strengthening.'
+      }`;
+
+  const creativeAnalysisOutput = creativeAnalysisText && creativeAnalysisText.trim().length > 5
+    ? creativeAnalysisText
+    : analysisNotes && analysisNotes.trim().length > 5
+      ? analysisNotes
+      : `Creative scored ${creativeScore.toFixed(1)}/10. ${
+          creativeScore >= 7
+            ? 'Creative shows strong conversion signals including visual clarity and offer visibility.'
+            : 'Creative analysis not provided. Score reflects available signals only. Full review recommended.'
+        }`;
+
+  const headlineAnalysisText = headline
+    ? `Headline scored ${(headlineScore ?? 0).toFixed(1)}/10. "${headline}" — ${
+        (headlineScore ?? 0) >= 7
+          ? 'Strong conversion intent with clear benefit or outcome framing.'
+          : (headlineScore ?? 0) >= 5
+            ? 'Present but lacks sharpness. Specificity and outcome focus should be strengthened.'
+            : 'Weak on conversion intent. Needs clearer outcome, pain-point hook, or specificity.'
+      }`
+    : 'Headline not provided. No score assigned. Adding a headline is strongly recommended.';
+
+  const descriptionAnalysisText = description
+    ? `Description scored ${(descriptionScore ?? 0).toFixed(1)}/10. ${
+        (descriptionScore ?? 0) >= 7
+          ? 'Reinforces the ad with useful proof, urgency, or risk reduction.'
+          : (descriptionScore ?? 0) >= 5
+            ? 'Present but adds limited conversion value. Consider adding proof or a risk reducer.'
+            : 'Weak. Should add something the headline and copy did not — proof, benefit, or risk reduction.'
+      }`
+    : 'Description not provided. No score assigned.';
+
+  const strengths: string[] = [];
+  const weaknesses: string[] = [];
+
+  if (copyScore >= 7) strengths.push('Copy demonstrates strong conversion signals.');
+  if (headlineScore !== null && headlineScore >= 7) strengths.push('Headline is clear, specific, and conversion-focused.');
+  if (creativeScore >= 7) strengths.push('Creative shows strong visual conversion signals.');
+  if (aidaScores.action >= 7) strengths.push('CTA and action intent are clearly communicated.');
+  if (convictionScore >= 7) strengths.push('Strong proof and conviction signals present.');
+  if (hasAuthorityAida && aidaAvg >= 8) strengths.push('Human analyst assessment confirms strong AIDA framework execution.');
+
+  if (copyScore < 5) weaknesses.push('Copy lacks sufficient conversion signals — hook, proof, or CTA are weak.');
+  if (headlineScore === null) weaknesses.push('No headline provided. Reduces stop-scroll and value transfer.');
+  if (headlineScore !== null && headlineScore < 5) weaknesses.push('Headline is weak on conversion intent.');
+  if (descriptionScore === null) weaknesses.push('No description provided. A short description can reduce hesitation.');
+  if (creativeScore < 5) weaknesses.push('Creative analysis absent or lacking conversion signals.');
+  if (convictionScore < 5) weaknesses.push('Low conviction — no clear proof, guarantee, or trust signals.');
+
+  // An ad qualifies only when score AND verdict are consistent.
+  // TOO_VAGUE_MAJOR_REWORK or INSUFFICIENT_INFORMATION = do not insert, even if score reaches 7.0.
+  const qualified = qualifies(overallScore)
+    && finalVerdict !== 'TOO_VAGUE_MAJOR_REWORK'
+    && finalVerdict !== 'INSUFFICIENT_INFORMATION';
 
   return {
+    // Backwards-compatible fields
     overallScore,
-    qualified: qualifies(overallScore),
+    qualified,
     subScores,
-    creativeAnalysis:
-      row['Creative Analysis'] ??
-      'Static creative was assessed for hierarchy, offer clarity, and trust signals.',
-    copyAnalysis:
-      row.Analysis ??
-      'Copy was assessed for relevance, value clarity, and funnel fit.',
-    headlineAnalysis: headline
-      ? `Headline emphasises: "${headline}". Strength is judged on clarity and outcome focus.`
-      : 'Headline missing; this reduces stop-scroll and value transfer.',
-    descriptionAnalysis: description
-      ? 'Description adds supporting context and should reinforce trust and CTA clarity.'
-      : 'Description missing; ad may lose context for lower-intent audiences.',
+    creativeAnalysis: creativeAnalysisOutput,
+    copyAnalysis: copyAnalysisText,
+    headlineAnalysis: headlineAnalysisText,
+    descriptionAnalysis: descriptionAnalysisText,
     aida: {
-      attention:
-        'Headline and visual treatment are scored for stop-scroll effect.',
-      interest:
-        'Copy relevance and product clarity are scored for audience fit.',
-      desire:
-        'Value proposition and trust signals are scored for motivation strength.',
-      action:
-        'CTA clarity and CTA visibility are scored for conversion intent.',
+      attention: `Score: ${aidaScores.attention.toFixed(1)}/10. ${aidaScores.attention >= 7 ? 'Strong hook and visual stopping power.' : 'Hook and first impression need strengthening.'}`,
+      interest: `Score: ${aidaScores.interest.toFixed(1)}/10. ${aidaScores.interest >= 7 ? 'Audience relevance and problem fit are clear.' : 'Audience specificity and problem clarity need work.'}`,
+      desire: `Score: ${aidaScores.desire.toFixed(1)}/10. ${aidaScores.desire >= 7 ? 'Benefit, proof, and offer are motivating.' : 'Benefit and proof signals need strengthening.'}`,
+      action: `Score: ${aidaScores.action.toFixed(1)}/10. ${aidaScores.action >= 7 ? 'CTA is clear and actionable.' : 'CTA and urgency signals need improvement.'}`,
     },
-    funnelStage: mapFunnelStage(copy),
-    raceStage: mapRaceStage(copy),
-    strengths: [
-      'Static-specific checks include visual hierarchy and trust signals.',
-      'Framework mapping is persisted for AIDA, funnel, and RACE.',
-    ],
-    weaknesses: [
-      ...(description ? [] : ['Description is missing or thin.']),
-      ...(headline ? [] : ['Headline is missing or too weak for stop-scroll.']),
-    ],
-    improvements: [
-      row.Improvement ??
-        'Make the CTA explicit and tie it to one clear outcome.',
-      row['Creative Improvements'] ??
-        'Increase contrast and product-first visual hierarchy.',
-      'Add a concrete trust marker (numbers, testimonial, or certification).',
-    ],
+    funnelStage,
+    raceStage,
+    strengths: strengths.length > 0 ? strengths : ['Insufficient signals to identify clear strengths.'],
+    weaknesses: weaknesses.length > 0 ? weaknesses : ['No major weaknesses detected from available signals.'],
+    improvements: [recommendations.copy, recommendations.headline, recommendations.creative],
+
+    // Phase 3.5 fields
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    aidaScores,
+    aidaExplanations: {
+      attention: `Hook clarity, first-frame stopping power, and visual impact. Score: ${aidaScores.attention.toFixed(1)}/10.`,
+      interest: `Audience relevance, problem-fit, and product clarity. Score: ${aidaScores.interest.toFixed(1)}/10.`,
+      desire: `Benefit specificity, proof strength, and offer clarity. Score: ${aidaScores.desire.toFixed(1)}/10.`,
+      action: `CTA directness, urgency signals, and friction reduction. Score: ${aidaScores.action.toFixed(1)}/10.`,
+    },
+    clarityScore,
+    connectionScore,
+    convictionScore,
+    trustFunnelStage,
+    behaviouralTriggers,
+    recommendations,
+    rewriteDirection,
+    finalVerdict,
   };
 }

--- a/lib/analysis/types.ts
+++ b/lib/analysis/types.ts
@@ -4,6 +4,57 @@ export type FunnelStage = 'TOFU' | 'MOFU' | 'BOFU';
 
 export type RaceStage = 'REACH' | 'ACT' | 'CONVERT' | 'ENGAGE';
 
+// Trust Funnel stages (Schwartz awareness ladder)
+export type TrustFunnelStage =
+  | 'UNAWARE'
+  | 'PROBLEM_AWARE'
+  | 'SOLUTION_AWARE'
+  | 'PRODUCT_AWARE'
+  | 'READY_TO_BUY';
+
+export type TriggerStrength = 'STRONG' | 'MODERATE' | 'WEAK' | 'MISSING';
+
+export type BehaviouralTrigger = {
+  name: string;
+  strength: TriggerStrength;
+};
+
+export type AidaScores = {
+  attention: number;
+  interest: number;
+  desire: number;
+  action: number;
+};
+
+export type AidaExplanations = {
+  attention: string;
+  interest: string;
+  desire: string;
+  action: string;
+};
+
+export type Recommendations = {
+  copy: string;
+  headline: string;
+  description: string;
+  creative: string;
+  conversionStrength: string;
+};
+
+export type RewriteDirection = {
+  hook: string;
+  body: string;
+  cta: string;
+  creativeDirection: string;
+} | null;
+
+export type FinalVerdict =
+  | 'STRONG_READY_TO_TEST'
+  | 'GOOD_NEEDS_SHARPENING'
+  | 'CLEAR_IDEA_WEAK_SIGNALS'
+  | 'TOO_VAGUE_MAJOR_REWORK'
+  | 'INSUFFICIENT_INFORMATION';
+
 export type ExampleRow = {
   Product: string;
   'Ad Link'?: string;
@@ -19,6 +70,7 @@ export type ExampleRow = {
   'Other Feedbacks'?: string;
 };
 
+// Kept for backwards compatibility — existing Prisma fields still use these keys
 export type SubScores = {
   // Shared (both static and video)
   hookStopScroll: number;
@@ -46,6 +98,7 @@ export type SubScores = {
   platformNativeFeel?: number;
 };
 
+// Kept for backwards compatibility
 export type AidaMapping = {
   attention: string;
   interest: string;
@@ -54,6 +107,7 @@ export type AidaMapping = {
 };
 
 export type AnalysisOutput = {
+  // --- Backwards-compatible fields (kept, not removed) ---
   overallScore: number;
   qualified: boolean;
   subScores: SubScores;
@@ -61,10 +115,30 @@ export type AnalysisOutput = {
   copyAnalysis: string;
   headlineAnalysis: string;
   descriptionAnalysis: string;
+  /** @deprecated Use aidaExplanations instead. Kept for backwards compatibility. */
   aida: AidaMapping;
   funnelStage: FunnelStage;
   raceStage: RaceStage;
   strengths: string[];
   weaknesses: string[];
   improvements: string[];
+
+  // --- Phase 3.5: Conversion-focused scoring fields ---
+  copyScore: number;
+  headlineScore: number | null;       // null = headline not provided
+  descriptionScore: number | null;    // null = description not provided
+  creativeScore: number;
+
+  aidaScores: AidaScores;
+  aidaExplanations: AidaExplanations;
+
+  clarityScore: number;
+  connectionScore: number;
+  convictionScore: number;
+
+  trustFunnelStage: TrustFunnelStage;
+  behaviouralTriggers: BehaviouralTrigger[];
+  recommendations: Recommendations;
+  rewriteDirection: RewriteDirection;  // null when all component scores >= 7
+  finalVerdict: FinalVerdict;
 };

--- a/lib/analysis/videoAnalyser.ts
+++ b/lib/analysis/videoAnalyser.ts
@@ -1,8 +1,21 @@
 import {
+  clampScore,
   deriveOverallScore,
+  deriveFinalVerdict,
+  deriveRecommendations,
+  deriveRewriteDirection,
+  detectBehaviouralTriggers,
+  extractAnalysisAidaScores,
   mapFunnelStage,
   mapRaceStage,
+  mapTrustFunnelStage,
   qualifies,
+  scoreAida,
+  scoreClarityConnectionConviction,
+  scoreCopyStrength,
+  scoreCreativeStrength,
+  scoreDescriptionStrength,
+  scoreHeadlineStrength,
   scoreBySignals,
 } from '@/lib/analysis/scoring';
 import type { AnalysisOutput, ExampleRow } from '@/lib/analysis/types';
@@ -11,101 +24,212 @@ export function analyseVideoAd(row: ExampleRow): AnalysisOutput {
   const copy = row.Copy ?? '';
   const headline = row.Headline ?? '';
   const description = row.Description ?? '';
-  const analysisReference = `${row.Analysis ?? ''} ${row['Creative Analysis'] ?? ''}`;
-  const allText = `${copy} ${headline} ${description} ${analysisReference}`;
+  const analysisNotes = row.Analysis ?? '';
+  const creativeAnalysisText = row['Creative Analysis'] ?? '';
+  const improvementNotes = row.Improvement ?? '';
+  const creativeImprovementNotes = row['Creative Improvements'] ?? '';
+  const otherFeedbacks = row['Other Feedbacks'] ?? '';
 
+  const allText = `${copy} ${headline} ${description} ${analysisNotes} ${creativeAnalysisText} ${otherFeedbacks}`;
+
+  // --- Phase 3.5: Conversion-focused component scores ---
+  const copyScore = scoreCopyStrength(copy, `${analysisNotes} ${otherFeedbacks}`);
+  const headlineScore = scoreHeadlineStrength(headline || undefined);
+  const descriptionScore = scoreDescriptionStrength(description || undefined);
+
+  // Pass analysisNotes so Creative Analysis fallback uses the rich analysis field
+  const creativeScore = scoreCreativeStrength(creativeAnalysisText, 'VIDEO', analysisNotes);
+
+  // Pass analysisNotes so explicit human AIDA scores (e.g. "Attention 9.2/10") are used when present
+  const aidaScores = scoreAida(copy, headline, creativeAnalysisText, analysisNotes);
+  const aidaAvg = clampScore(
+    (aidaScores.attention + aidaScores.interest + aidaScores.desire + aidaScores.action) / 4,
+  );
+
+  // Pass analysisNotes so rich analysis text informs CCC scoring
+  const { clarity: clarityScore, connection: connectionScore, conviction: convictionScore } =
+    scoreClarityConnectionConviction(copy, headline, description, analysisNotes);
+
+  const trustFunnelStage = mapTrustFunnelStage(copy, headline);
+  const funnelStage = mapFunnelStage(copy);
+  const raceStage = mapRaceStage(copy);
+
+  // Pass analysisNotes so human analyst language surfaces behavioural triggers
+  const behaviouralTriggers = detectBehaviouralTriggers(copy, headline, creativeAnalysisText, analysisNotes);
+
+  const recommendations = deriveRecommendations(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    improvementNotes,
+    creativeImprovementNotes,
+  );
+
+  // --- Overall score ---
+  // When the human analyst has written explicit numeric AIDA scores in their analysis,
+  // those scores are authoritative evidence — weight them 55% vs 45% for pattern scores.
+  // Rationale: a human reviewing the actual ad is more reliable than regex on sparse copy text.
+  const hasAuthorityAida = extractAnalysisAidaScores(analysisNotes) !== null;
+
+  let overallScore: number;
+  if (hasAuthorityAida) {
+    const otherInputs = [copyScore, creativeScore, clarityScore, connectionScore, convictionScore];
+    if (headlineScore !== null) otherInputs.push(headlineScore);
+    if (descriptionScore !== null) otherInputs.push(descriptionScore);
+    const otherAvg = deriveOverallScore(otherInputs);
+    overallScore = clampScore(aidaAvg * 0.55 + otherAvg * 0.45);
+  } else {
+    const scoringInputs = [copyScore, creativeScore, aidaAvg, clarityScore, connectionScore, convictionScore];
+    if (headlineScore !== null) scoringInputs.push(headlineScore);
+    if (descriptionScore !== null) scoringInputs.push(descriptionScore);
+    overallScore = deriveOverallScore(scoringInputs);
+  }
+
+  const rewriteDirection = deriveRewriteDirection(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    copy,
+    funnelStage,
+  );
+
+  const finalVerdict = deriveFinalVerdict(
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    overallScore,
+  );
+
+  // --- Backwards-compatible SubScores (kept for existing Prisma fields) ---
+  // Video-specific signals included
   const subScores = {
-    hookStopScroll: scoreBySignals(allText, [
-      /hook|0-3|first\s*(three|3)|stop-scroll/i,
-      /bold|strong opening|pattern interrupt/i,
-    ]),
-    audienceRelevance: scoreBySignals(allText, [
-      /audience|target|persona|for\s+\w+/i,
-      /pain point|problem/i,
-    ]),
-    valueClarity: scoreBySignals(allText, [
-      /benefit|value|outcome|result|transform/i,
-      /clear|simple/i,
-    ]),
-    trustProofStrength: scoreBySignals(allText, [
-      /testimonial|proof|real|case study|results/i,
-      /credibility|guarantee|review/i,
-    ]),
-    ctaClarity: scoreBySignals(allText, [
-      /book|start|get started|learn more|shop|register/i,
-      /now|today/i,
-    ]),
-    firstThreeSeconds: scoreBySignals(analysisReference, [
-      /0-3|first\s*(three|3)|opening/i,
-    ]),
-    soundOffDesign: scoreBySignals(analysisReference, [
-      /caption|subtitle|sound-off|text overlay/i,
-    ]),
-    soundOnEnhancement: scoreBySignals(analysisReference, [
-      /voice|audio|music|sound-on/i,
-    ]),
-    onScreenText: scoreBySignals(analysisReference, [
-      /on-screen|overlay|text|caption/i,
-    ]),
-    storyFlow: scoreBySignals(analysisReference, [
-      /story|flow|sequence|narrative/i,
-    ]),
-    authenticity: scoreBySignals(analysisReference, [
-      /authentic|real people|founder|customer/i,
-    ]),
-    platformNativeFeel: scoreBySignals(analysisReference, [
-      /reels|stories|ugc|platform-native|vertical/i,
-    ]),
+    hookStopScroll: scoreBySignals(allText, [/hook|0-3|first\s*(three|3)|stop-scroll/i, /bold|strong opening|pattern interrupt/i]),
+    audienceRelevance: scoreBySignals(allText, [/audience|target|persona|for\s+\w+/i, /pain point|problem/i]),
+    valueClarity: scoreBySignals(allText, [/benefit|value|outcome|result|transform/i, /clear|simple/i]),
+    trustProofStrength: scoreBySignals(allText, [/testimonial|proof|real|case study|results/i, /credibility|guarantee|review/i]),
+    ctaClarity: scoreBySignals(allText, [/book|start|get started|learn more|shop|register/i, /now|today/i]),
+    firstThreeSeconds: scoreBySignals(creativeAnalysisText || analysisNotes, [/0-3|first\s*(three|3)|opening|hook/i]),
+    soundOffDesign: scoreBySignals(creativeAnalysisText || analysisNotes, [/caption|subtitle|sound.off|text overlay|on.screen/i]),
+    soundOnEnhancement: scoreBySignals(creativeAnalysisText || analysisNotes, [/voice|audio|music|sound.on/i]),
+    onScreenText: scoreBySignals(creativeAnalysisText || analysisNotes, [/on.screen|overlay|text|caption/i]),
+    storyFlow: scoreBySignals(creativeAnalysisText || analysisNotes, [/story|flow|sequence|narrative|montage/i]),
+    authenticity: scoreBySignals(creativeAnalysisText || analysisNotes, [/authentic|real people|founder|customer|testimonial/i]),
+    platformNativeFeel: scoreBySignals(creativeAnalysisText || analysisNotes, [/reels|stories|ugc|platform.native|vertical/i]),
   };
 
-  const overallScore = deriveOverallScore(Object.values(subScores));
+  // --- Narrative analysis fields ---
+  const copyAnalysisText = analysisNotes && analysisNotes.trim().length > 5
+    ? analysisNotes
+    : `Copy scored ${copyScore.toFixed(1)}/10. ${
+        copyScore >= 7
+          ? 'Strong conversion signals detected. Hook, benefit, and CTA are present.'
+          : copyScore >= 5
+            ? 'Moderate signals. Some conversion elements are present but not fully sharpened.'
+            : 'Weak conversion signals. Hook, proof, and CTA need significant strengthening.'
+      }`;
+
+  const creativeAnalysisOutput = creativeAnalysisText && creativeAnalysisText.trim().length > 5
+    ? creativeAnalysisText
+    : analysisNotes && analysisNotes.trim().length > 5
+      ? analysisNotes
+      : `Creative scored ${creativeScore.toFixed(1)}/10. ${
+          creativeScore >= 7
+            ? 'Video creative shows strong conversion signals. Opening hook, sound-off design, and CTA are well-executed.'
+            : 'Video creative analysis not provided. Score reflects available signals only. Assess first 3 seconds, sound-off readability, and CTA visibility.'
+        }`;
+
+  const headlineAnalysisText = headline
+    ? `Headline scored ${(headlineScore ?? 0).toFixed(1)}/10. "${headline}" — ${
+        (headlineScore ?? 0) >= 7
+          ? 'Strong conversion intent. Supports the video narrative and conversion goal.'
+          : (headlineScore ?? 0) >= 5
+            ? 'Present but not sharp enough to drive clicks independently of the video.'
+            : 'Weak on conversion intent. Needs clearer outcome, pain-point hook, or specificity.'
+      }`
+    : 'Headline not provided. No score assigned. A headline can drive clicks when the video is skipped.';
+
+  const descriptionAnalysisText = description
+    ? `Description scored ${(descriptionScore ?? 0).toFixed(1)}/10. ${
+        (descriptionScore ?? 0) >= 7
+          ? 'Reinforces the video message with proof, urgency, or risk reduction.'
+          : (descriptionScore ?? 0) >= 5
+            ? 'Present but adds limited conversion value. Consider proof or a risk reducer.'
+            : 'Weak. Should add something the video and copy did not — proof, benefit, or risk reduction.'
+      }`
+    : 'Description not provided. No score assigned.';
+
+  const strengths: string[] = [];
+  const weaknesses: string[] = [];
+
+  if (copyScore >= 7) strengths.push('Copy demonstrates strong conversion signals.');
+  if (headlineScore !== null && headlineScore >= 7) strengths.push('Headline is clear, specific, and conversion-focused.');
+  if (creativeScore >= 7) strengths.push('Video creative shows strong conversion execution.');
+  if (aidaScores.attention >= 7) strengths.push('Opening hook and attention mechanics are strong.');
+  if (convictionScore >= 7) strengths.push('Strong proof and conviction signals present.');
+  if (hasAuthorityAida && aidaAvg >= 8) strengths.push('Human analyst assessment confirms strong AIDA framework execution.');
+  if (/caption|subtitle|sound.off|text overlay/i.test(creativeAnalysisText || analysisNotes)) {
+    strengths.push('Sound-off design is addressed — critical for feed environments.');
+  }
+
+  if (copyScore < 5) weaknesses.push('Copy lacks sufficient conversion signals — hook, proof, or CTA are weak.');
+  if (headlineScore === null) weaknesses.push('No headline provided. Reduces click potential when video is skipped.');
+  if (headlineScore !== null && headlineScore < 5) weaknesses.push('Headline is weak on conversion intent.');
+  if (descriptionScore === null) weaknesses.push('No description provided. Can reduce hesitation in lower-intent viewers.');
+  if (creativeScore < 5) weaknesses.push('Video creative analysis absent or lacking conversion signals.');
+  if (convictionScore < 5) weaknesses.push('Low conviction — no clear proof, guarantee, or trust signals.');
+  if (!/caption|subtitle|sound.off|text overlay/i.test(creativeAnalysisText || analysisNotes)) {
+    weaknesses.push('No evidence of sound-off design. Most video ads are watched on mute — captions or text overlays are essential.');
+  }
+
+  // An ad qualifies only when score AND verdict are consistent.
+  // TOO_VAGUE_MAJOR_REWORK or INSUFFICIENT_INFORMATION = do not insert, even if score reaches 7.0.
+  const qualified = qualifies(overallScore)
+    && finalVerdict !== 'TOO_VAGUE_MAJOR_REWORK'
+    && finalVerdict !== 'INSUFFICIENT_INFORMATION';
 
   return {
+    // Backwards-compatible fields
     overallScore,
-    qualified: qualifies(overallScore),
+    qualified,
     subScores,
-    creativeAnalysis:
-      row['Creative Analysis'] ??
-      'Video creative was assessed for first 0–3 seconds, flow, and platform-native fit.',
-    copyAnalysis:
-      row.Analysis ??
-      'Video copy was assessed for relevance, value clarity, and CTA direction.',
-    headlineAnalysis: headline
-      ? `Headline supports video narrative: "${headline}".`
-      : 'Headline missing; this can reduce context when users skim quickly.',
-    descriptionAnalysis: description
-      ? 'Description complements video messaging and can support stronger conversion intent.'
-      : 'Description missing; add short supporting detail for feed context.',
+    creativeAnalysis: creativeAnalysisOutput,
+    copyAnalysis: copyAnalysisText,
+    headlineAnalysis: headlineAnalysisText,
+    descriptionAnalysis: descriptionAnalysisText,
     aida: {
-      attention:
-        'Opening 0–3 seconds and stop-scroll strength are scored as primary Attention drivers.',
-      interest:
-        'Story flow and audience relevance are scored to maintain Interest.',
-      desire:
-        'Value clarity and trust/proof cues are scored for Desire.',
-      action:
-        'CTA clarity plus sound-off/on execution are scored for Action readiness.',
+      attention: `Score: ${aidaScores.attention.toFixed(1)}/10. ${aidaScores.attention >= 7 ? 'Strong opening hook and visual stopping power.' : 'Opening hook and first-frame impact need strengthening.'}`,
+      interest: `Score: ${aidaScores.interest.toFixed(1)}/10. ${aidaScores.interest >= 7 ? 'Story flow and audience relevance maintain interest.' : 'Story flow and audience specificity need improvement.'}`,
+      desire: `Score: ${aidaScores.desire.toFixed(1)}/10. ${aidaScores.desire >= 7 ? 'Benefit clarity and proof cues drive desire.' : 'Benefit and proof signals need strengthening.'}`,
+      action: `Score: ${aidaScores.action.toFixed(1)}/10. ${aidaScores.action >= 7 ? 'CTA is clear and action-oriented.' : 'CTA and urgency needs improvement for conversion readiness.'}`,
     },
-    funnelStage: mapFunnelStage(copy),
-    raceStage: mapRaceStage(copy),
-    strengths: [
-      'Video-specific checks capture sound-off design and opening hook quality.',
-      'On-screen text and platform-native feel are explicitly scored.',
-    ],
-    weaknesses: [
-      ...(analysisReference.match(/caption|subtitle|sound-off/i)
-        ? []
-        : ['Limited explicit sound-off support detected.']),
-      ...(analysisReference.match(/story|flow|sequence/i)
-        ? []
-        : ['Story flow is not explicit in the reference notes.']),
-    ],
-    improvements: [
-      row.Improvement ??
-        'Strengthen the first three seconds with a clear pain-point hook.',
-      row['Creative Improvements'] ??
-        'Add readable on-screen text for sound-off viewing.',
-      'Use a clearer single CTA in the final third of the video.',
-    ],
+    funnelStage,
+    raceStage,
+    strengths: strengths.length > 0 ? strengths : ['Insufficient signals to identify clear strengths.'],
+    weaknesses: weaknesses.length > 0 ? weaknesses : ['No major weaknesses detected from available signals.'],
+    improvements: [recommendations.copy, recommendations.headline, recommendations.creative],
+
+    // Phase 3.5 fields
+    copyScore,
+    headlineScore,
+    descriptionScore,
+    creativeScore,
+    aidaScores,
+    aidaExplanations: {
+      attention: `Opening hook, first-frame impact, and pattern interrupt strength. Score: ${aidaScores.attention.toFixed(1)}/10.`,
+      interest: `Story flow, audience relevance, and problem fit. Score: ${aidaScores.interest.toFixed(1)}/10.`,
+      desire: `Benefit specificity, proof strength, and offer clarity. Score: ${aidaScores.desire.toFixed(1)}/10.`,
+      action: `CTA directness, urgency signals, and friction reduction. Score: ${aidaScores.action.toFixed(1)}/10.`,
+    },
+    clarityScore,
+    connectionScore,
+    convictionScore,
+    trustFunnelStage,
+    behaviouralTriggers,
+    recommendations,
+    rewriteDirection,
+    finalVerdict,
   };
 }

--- a/lib/ingestion/manualIngestion.ts
+++ b/lib/ingestion/manualIngestion.ts
@@ -94,6 +94,26 @@ export async function ingestExampleRows(params: {
         weaknessesJson: JSON.stringify(analysed.weaknesses),
         improvementsJson: JSON.stringify(analysed.improvements),
         rubricScoresJson: JSON.stringify(analysed.subScores),
+
+        // Phase 3.5: Conversion-focused scoring fields
+        copyScore: analysed.copyScore,
+        headlineScore: analysed.headlineScore,
+        descriptionScore: analysed.descriptionScore,
+        creativeScore: analysed.creativeScore,
+        aidaAttentionScore: analysed.aidaScores.attention,
+        aidaInterestScore: analysed.aidaScores.interest,
+        aidaDesireScore: analysed.aidaScores.desire,
+        aidaActionScore: analysed.aidaScores.action,
+        clarityScore: analysed.clarityScore,
+        connectionScore: analysed.connectionScore,
+        convictionScore: analysed.convictionScore,
+        trustFunnelStage: analysed.trustFunnelStage,
+        behaviouralTriggersJson: JSON.stringify(analysed.behaviouralTriggers),
+        recommendationsJson: JSON.stringify(analysed.recommendations),
+        rewriteDirectionJson: analysed.rewriteDirection
+          ? JSON.stringify(analysed.rewriteDirection)
+          : null,
+        finalVerdict: analysed.finalVerdict,
       },
     });
 

--- a/prisma/migrations/20260504073228_phase3_5_conversion_scoring/migration.sql
+++ b/prisma/migrations/20260504073228_phase3_5_conversion_scoring/migration.sql
@@ -1,0 +1,19 @@
+-- Phase 3.5: Add conversion-focused scoring fields to AdAnalysis
+-- All columns are nullable for full backwards compatibility with existing rows.
+
+ALTER TABLE "AdAnalysis" ADD COLUMN "copyScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "headlineScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "descriptionScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "creativeScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "aidaAttentionScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "aidaInterestScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "aidaDesireScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "aidaActionScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "clarityScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "connectionScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "convictionScore" REAL;
+ALTER TABLE "AdAnalysis" ADD COLUMN "trustFunnelStage" TEXT;
+ALTER TABLE "AdAnalysis" ADD COLUMN "behaviouralTriggersJson" TEXT;
+ALTER TABLE "AdAnalysis" ADD COLUMN "recommendationsJson" TEXT;
+ALTER TABLE "AdAnalysis" ADD COLUMN "rewriteDirectionJson" TEXT;
+ALTER TABLE "AdAnalysis" ADD COLUMN "finalVerdict" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,6 +121,24 @@ model AdAnalysis {
   funnelStage                String?
   raceStage                  String?
 
+  // Phase 3.5: Conversion-focused scoring fields (all nullable for backwards compatibility)
+  copyScore                  Float?
+  headlineScore              Float?   // null = headline not provided
+  descriptionScore           Float?   // null = description not provided
+  creativeScore              Float?
+  aidaAttentionScore         Float?
+  aidaInterestScore          Float?
+  aidaDesireScore            Float?
+  aidaActionScore            Float?
+  clarityScore               Float?
+  connectionScore            Float?
+  convictionScore            Float?
+  trustFunnelStage           String?
+  behaviouralTriggersJson    String?
+  recommendationsJson        String?
+  rewriteDirectionJson       String?
+  finalVerdict               String?
+
   createdAt                  DateTime @default(now())
   updatedAt                  DateTime @updatedAt
 }

--- a/scripts/verify-runtime.ts
+++ b/scripts/verify-runtime.ts
@@ -301,6 +301,117 @@ async function run(): Promise<void> {
     failures += 1;
   }
 
+  // --- Phase 3.5 checks: conversion-focused scoring fields ---
+
+  const PHASE_3_5_REQUIRED_FIELDS = [
+    'copyScore',
+    'creativeScore',
+    'clarityScore',
+    'connectionScore',
+    'convictionScore',
+    'trustFunnelStage',
+    'finalVerdict',
+    'behaviouralTriggersJson',
+    'recommendationsJson',
+  ] as const;
+
+  const VALID_VERDICTS = [
+    'STRONG_READY_TO_TEST',
+    'GOOD_NEEDS_SHARPENING',
+    'CLEAR_IDEA_WEAK_SIGNALS',
+    'TOO_VAGUE_MAJOR_REWORK',
+    'INSUFFICIENT_INFORMATION',
+  ];
+
+  const VALID_TRUST_FUNNEL_STAGES = [
+    'UNAWARE',
+    'PROBLEM_AWARE',
+    'SOLUTION_AWARE',
+    'PRODUCT_AWARE',
+    'READY_TO_BUY',
+  ];
+
+  let conversionFieldsOk = true;
+  const conversionFieldErrors: string[] = [];
+
+  for (const ad of allAds) {
+    const a = ad.analysis;
+    if (!a) { conversionFieldsOk = false; continue; }
+
+    for (const field of PHASE_3_5_REQUIRED_FIELDS) {
+      const value = a[field as keyof typeof a];
+      if (value === null || value === undefined) {
+        conversionFieldsOk = false;
+        conversionFieldErrors.push(`Ad ${ad.id}: ${field} is null/undefined`);
+      }
+    }
+
+    if (a.finalVerdict && !VALID_VERDICTS.includes(a.finalVerdict)) {
+      conversionFieldsOk = false;
+      conversionFieldErrors.push(`Ad ${ad.id}: invalid finalVerdict "${a.finalVerdict}"`);
+    }
+
+    if (a.trustFunnelStage && !VALID_TRUST_FUNNEL_STAGES.includes(a.trustFunnelStage)) {
+      conversionFieldsOk = false;
+      conversionFieldErrors.push(`Ad ${ad.id}: invalid trustFunnelStage "${a.trustFunnelStage}"`);
+    }
+
+    if (a.behaviouralTriggersJson) {
+      try {
+        const triggers = JSON.parse(a.behaviouralTriggersJson);
+        if (!Array.isArray(triggers) || triggers.length === 0) {
+          conversionFieldsOk = false;
+          conversionFieldErrors.push(`Ad ${ad.id}: behaviouralTriggersJson is empty array`);
+        }
+      } catch {
+        conversionFieldsOk = false;
+        conversionFieldErrors.push(`Ad ${ad.id}: behaviouralTriggersJson is invalid JSON`);
+      }
+    }
+
+    if (a.recommendationsJson) {
+      try {
+        const recs = JSON.parse(a.recommendationsJson);
+        const recKeys = ['copy', 'headline', 'description', 'creative', 'conversionStrength'];
+        const hasAllKeys = recKeys.every((k) => typeof recs[k] === 'string' && recs[k].length > 0);
+        if (!hasAllKeys) {
+          conversionFieldsOk = false;
+          conversionFieldErrors.push(`Ad ${ad.id}: recommendationsJson missing required keys`);
+        }
+      } catch {
+        conversionFieldsOk = false;
+        conversionFieldErrors.push(`Ad ${ad.id}: recommendationsJson is invalid JSON`);
+      }
+    }
+  }
+
+  if (conversionFieldsOk) {
+    pass('Phase 3.5 conversion scoring fields populated on all analyses');
+  } else {
+    fail('Phase 3.5 conversion scoring fields missing or invalid', conversionFieldErrors.slice(0, 5));
+    failures += 1;
+  }
+
+  // Phase 3.5: Show example conversion summary for one ad
+  const exampleAd = allAds[0];
+  if (exampleAd?.analysis) {
+    const ea = exampleAd.analysis;
+    pass('Phase 3.5 example conversion summary', {
+      adId: exampleAd.id,
+      format: exampleAd.adFormat,
+      overallScore: ea.overallScore,
+      copyScore: ea.copyScore,
+      headlineScore: ea.headlineScore,
+      descriptionScore: ea.descriptionScore,
+      creativeScore: ea.creativeScore,
+      clarityScore: ea.clarityScore,
+      connectionScore: ea.connectionScore,
+      convictionScore: ea.convictionScore,
+      trustFunnelStage: ea.trustFunnelStage,
+      finalVerdict: ea.finalVerdict,
+    });
+  }
+
   console.log('\nFinal inserted counts:');
   console.log(JSON.stringify(counts, null, 2));
 


### PR DESCRIPTION
## Summary
Adds Phase 3.5 conversion-led ad analysis and ad detail layout.

## What changed
- Extended analysis output types with conversion-led scoring fields.
- Added component scores for copy, headline, description, creative, AIDA, clarity, connection, and conviction.
- Added behavioural trigger, recommendation, rewrite direction, Trust Funnel, and final verdict fields.
- Updated static and video analysers to score based on conversion signals.
- Updated ingestion to persist the new analysis fields.
- Added nullable Prisma fields to `AdAnalysis`.
- Added migration for Phase 3.5 conversion scoring fields.
- Reworked the ad detail page into the new conversion-focused analysis flow.
- Updated runtime verification to check the new fields.

## Verification
Passed locally:
- `npm run db:generate`
- `npx prisma migrate reset --force`
- `npm run verify:runtime`
- `npm run build`

Runtime verification confirmed:
- industries inserted: 314
- clients inserted: 508
- competitors inserted: 1
- ads inserted: 1
- ad_analysis inserted: 1
- no qualified ads below 7.0 were saved
- dashboard proof passed
- ad detail proof passed
- final verdict consistency fixed: qualified ad now shows `GOOD_NEEDS_SHARPENING`, not `TOO_VAGUE_MAJOR_REWORK`

## Notes
- `package-lock.json` was intentionally not included because it was generated locally and is not currently tracked on `main`.
- Phase 4 Meta fetch/provider work is not included in this PR.
- No live Meta collection, scheduled scans, or provider changes are included.