### PR TITLE
Phase 4 Step 1: Add token-safe Meta dry run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,26 @@
 # Beginner local mode (SQLite, no Docker, no Postgres)
 DATABASE_URL="file:./dev.db"
+
+# ── Meta Ad Library ───────────────────────────────────────────────────────────
+# Required for live API fetch. Leave unset to run in simulation mode.
+# How to generate: https://developers.facebook.com/tools/explorer/
+# Required permission: ads_read
+# Short-lived tokens expire in ~1–2 hours. Long-lived tokens last ~60 days.
+META_ADLIB_TOKEN=
+
+# Comma-separated ISO country codes to scope the ad search (e.g. SG,MY)
+META_COUNTRIES=SG
+
+# Keyword(s) passed to search_terms in the Meta Ad Library API request
+META_SEARCH_TERMS=skincare
+
+# Ad format for this run: STATIC or VIDEO
+# Format is set per-query (not per-record) — run separately for each format.
+META_AD_FORMAT=STATIC
+
+# Number of ads to fetch per run (max 25 recommended)
+META_FETCH_LIMIT=5
+
+# Set to true to force simulation mode even when META_ADLIB_TOKEN is set.
+# Simulation mode returns mock records without any network call.
+META_SIMULATION_MODE=true

--- a/lib/providers/meta/fetch.ts
+++ b/lib/providers/meta/fetch.ts
@@ -1,0 +1,199 @@
+import { redactToken, safeLog } from '@/lib/providers/meta/redact';
+import type { MetaAdRecord, MetaApiResponse, MetaFetchConfig } from '@/lib/providers/meta/types';
+
+const META_API_BASE = 'https://graph.facebook.com/v25.0/ads_archive';
+
+const FIELDS = [
+  'ad_creation_time',
+  'ad_delivery_start_time',
+  'ad_delivery_stop_time',
+  'ad_snapshot_url',
+  'page_id',
+  'page_name',
+  'ad_creative_bodies',
+  'ad_creative_link_titles',
+  'ad_creative_link_descriptions',
+  'publisher_platforms',
+].join(',');
+
+// ─── Simulation data ──────────────────────────────────────────────────────────
+
+/**
+ * Realistic mock records that prove the normalise → analyse pipeline
+ * without a real Meta API call. One STATIC-shaped and one VIDEO-shaped
+ * record included so the dry-run covers both analytical paths.
+ *
+ * These are NOT real ads. Field shapes mirror real Meta API responses.
+ */
+function getSimulatedRecords(): MetaAdRecord[] {
+  return [
+    {
+      id: 'sim-001',
+      page_name: 'Glow Skincare SG',
+      page_id: '100001234567890',
+      ad_creative_bodies: [
+        'Discover our new Vitamin C serum — clinically proven to brighten skin in 14 days. ' +
+        'Get started with a free trial today. Trusted by over 50,000 customers in Singapore.',
+      ],
+      ad_creative_link_titles: ['Get Your Free Vitamin C Serum Trial'],
+      ad_creative_link_descriptions: [
+        'Start your skincare transformation. Limited time offer — free shipping on all orders.',
+      ],
+      ad_snapshot_url: 'https://www.facebook.com/ads/archive/render_ad/?id=111222333',
+      ad_delivery_start_time: '2026-03-15T00:00:00+0800',
+      ad_delivery_stop_time: null,
+      ad_creation_time: '2026-03-14T10:30:00+0800',
+      publisher_platforms: ['facebook', 'instagram'],
+    },
+    {
+      id: 'sim-002',
+      page_name: 'Dr Jart+ Singapore',
+      page_id: '100009876543210',
+      ad_creative_bodies: [
+        'NEW Ceramidin Cream — your skin barrier\'s best friend. ' +
+        'Book a consultation at our Orchard Road store. Results guaranteed or your money back.',
+      ],
+      ad_creative_link_titles: ['Shop Ceramidin Cream Now'],
+      ad_creative_link_descriptions: [
+        'Dermatologist-recommended skincare. Compare our range and find your perfect match.',
+      ],
+      ad_snapshot_url: 'https://www.facebook.com/ads/archive/render_ad/?id=444555666',
+      ad_delivery_start_time: '2026-02-01T00:00:00+0800',
+      ad_delivery_stop_time: '2026-04-01T00:00:00+0800',
+      ad_creation_time: '2026-01-28T14:00:00+0800',
+      publisher_platforms: ['facebook'],
+    },
+    {
+      id: 'sim-003',
+      page_name: 'The Ordinary SG',
+      page_id: '100005555555555',
+      ad_creative_bodies: [
+        'Hyaluronic Acid 2% + B5. Simple, effective hydration for every skin type. ' +
+        'Learn more about our science-first approach to skincare.',
+      ],
+      ad_creative_link_titles: ['Explore The Ordinary Range'],
+      ad_creative_link_descriptions: undefined,
+      ad_snapshot_url: 'https://www.facebook.com/ads/archive/render_ad/?id=777888999',
+      ad_delivery_start_time: '2026-04-10T00:00:00+0800',
+      ad_delivery_stop_time: null,
+      ad_creation_time: '2026-04-09T08:00:00+0800',
+      publisher_platforms: ['facebook', 'instagram', 'audience_network'],
+    },
+  ];
+}
+
+// ─── Live fetch ───────────────────────────────────────────────────────────────
+
+async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
+  const params = new URLSearchParams({
+    search_terms: config.searchTerms,
+    ad_reached_countries: `['${config.countries.join("','")}']`,
+    ad_active_status: config.adActiveStatus,
+    fields: FIELDS,
+    limit: String(config.limit),
+    access_token: config.token!, // present — checked before calling this function
+  });
+
+  // Log the request without the token in the URL
+  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
+  console.log(`\n  Fetching from Meta Ad Library API...`);
+  console.log(`  Search terms:  ${config.searchTerms}`);
+  console.log(`  Countries:     ${config.countries.join(', ')}`);
+  console.log(`  Active status: ${config.adActiveStatus}`);
+  console.log(`  Limit:         ${config.limit}`);
+  console.log(`  URL:           ${safeDisplayUrl}`);
+
+  const fullUrl = `${META_API_BASE}?${params.toString()}`;
+  const response = await fetch(fullUrl);
+  const json = (await response.json()) as MetaApiResponse;
+
+  if (json.error) {
+    // Redact token from error messages before throwing
+    const safeMessage = redactToken(
+      `Meta API error (code ${json.error.code}): ${json.error.message}`,
+    );
+    throw new Error(safeMessage);
+  }
+
+  if (!json.data || json.data.length === 0) {
+    throw new Error('Meta API returned no ads for this search. Try a different search_terms or country.');
+  }
+
+  console.log(`  ✓ Received ${json.data.length} ad(s)`);
+
+  // paging.next is a token-bearing URL — log only whether pagination exists,
+  // never the URL itself. Step 1 does not follow pagination.
+  if (json.paging?.next) {
+    console.log(`  ℹ  Pagination available — not followed in Step 1 (single page only)`);
+  }
+
+  return json.data;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetches ads from the Meta Ad Library API, or returns simulation data if
+ * no token is configured or simulation mode is explicitly set.
+ *
+ * Token safety:
+ *  - The token never appears in log output
+ *  - Error messages are redacted before throwing
+ *  - paging.next is consumed internally and never logged
+ *  - ad_snapshot_url values are logged via safeLog() in the calling script
+ */
+export async function fetchMetaAds(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
+  const isSimulation = config.simulationMode || !config.token;
+
+  if (isSimulation) {
+    const records = getSimulatedRecords();
+    console.log(`\n  Mode: SIMULATION (META_ADLIB_TOKEN not set)`);
+    console.log(`  Returning ${records.length} mock record(s)`);
+    console.log(`  ⚠  This proves normalise → analyse pipeline only.`);
+    console.log(`     Set META_ADLIB_TOKEN to test real API fetch.`);
+    return records;
+  }
+
+  console.log(`\n  Mode: LIVE API FETCH (META_ADLIB_TOKEN detected)`);
+  return fetchFromApi(config);
+}
+
+// ─── Config builder ───────────────────────────────────────────────────────────
+
+/**
+ * Builds MetaFetchConfig from environment variables.
+ * All values have safe defaults so the dry-run works with no env vars set.
+ *
+ * Environment variables:
+ *   META_ADLIB_TOKEN    — access token (absent = simulation mode)
+ *   META_SEARCH_TERMS   — keyword(s) passed to search_terms (default: 'skincare')
+ *   META_COUNTRIES      — comma-separated ISO codes (default: 'SG')
+ *   META_FETCH_LIMIT    — number of ads to fetch (default: 5, max: 25)
+ *   META_AD_FORMAT      — 'STATIC' or 'VIDEO' (default: 'STATIC')
+ *   META_SIMULATION_MODE — 'true' forces simulation even if token is set
+ */
+export function buildConfigFromEnv(): MetaFetchConfig {
+  const token = process.env.META_ADLIB_TOKEN || undefined;
+  const searchTerms = process.env.META_SEARCH_TERMS ?? 'skincare';
+  const countries = (process.env.META_COUNTRIES ?? 'SG')
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const limit = Math.min(
+    parseInt(process.env.META_FETCH_LIMIT ?? '5', 10) || 5,
+    25,
+  );
+  const rawFormat = (process.env.META_AD_FORMAT ?? 'STATIC').toUpperCase();
+  const format = rawFormat === 'VIDEO' ? 'VIDEO' : 'STATIC';
+  const simulationMode = process.env.META_SIMULATION_MODE === 'true';
+
+  return {
+    token,
+    searchTerms,
+    countries,
+    adActiveStatus: 'ALL',
+    limit,
+    format,
+    simulationMode,
+  };
+}

--- a/lib/providers/meta/redact.ts
+++ b/lib/providers/meta/redact.ts
@@ -1,0 +1,45 @@
+/**
+ * Token redaction helpers for the Meta provider.
+ *
+ * Rules enforced here:
+ *  - access_token values are never printed raw in any string
+ *  - ad_snapshot_url values containing access_token are never printed raw
+ *  - paging.next is never passed to these functions at all (callers discard it)
+ *  - All URL-shaped fields in log output go through safeUrlLabel()
+ *  - All error messages go through redactToken() before printing
+ */
+
+/**
+ * Replaces the value of any `access_token` query parameter in a string
+ * with `REDACTED`. Safe to call on full URLs or partial strings.
+ *
+ * Example:
+ *   "...&access_token=EAAxxxYYY&other=1"
+ *   → "...&access_token=REDACTED&other=1"
+ */
+export function redactToken(value: string): string {
+  return value.replace(/access_token=[^&\s"']*/gi, 'access_token=REDACTED');
+}
+
+/**
+ * Returns a safe label for a URL that may contain an access_token.
+ *
+ * - If the URL contains `access_token=`, returns 'present (token redacted)'
+ * - If the URL is absent or empty, returns 'N/A'
+ * - Otherwise returns the URL as-is (no token present)
+ *
+ * Used for ad_snapshot_url and Ad Link fields in log output.
+ */
+export function safeUrlLabel(url: string | undefined | null): string {
+  if (!url) return 'N/A';
+  if (/access_token=/i.test(url)) return 'present (token redacted)';
+  return url;
+}
+
+/**
+ * Logs a labelled URL field safely.
+ * Convenience wrapper so callers never need to remember to call safeUrlLabel.
+ */
+export function safeLog(label: string, url: string | undefined | null): void {
+  console.log(`${label}${safeUrlLabel(url)}`);
+}

--- a/lib/providers/meta/types.ts
+++ b/lib/providers/meta/types.ts
@@ -1,0 +1,61 @@
+import type { AdFormat } from '@/lib/analysis/types';
+
+/**
+ * Raw shape of a single ad record returned by the Meta Ad Library API.
+ * Fields map to what `GET /v25.0/ads_archive` returns for the field list
+ * used in this project.
+ */
+export type MetaAdRecord = {
+  id?: string;
+  page_name?: string;
+  page_id?: string;
+  ad_creative_bodies?: string[];
+  ad_creative_link_titles?: string[];
+  ad_creative_link_descriptions?: string[];
+  ad_snapshot_url?: string;
+  ad_delivery_start_time?: string;
+  ad_delivery_stop_time?: string | null;
+  ad_creation_time?: string;
+  publisher_platforms?: string[];
+};
+
+/**
+ * Outer envelope returned by the Meta Ad Library API.
+ */
+export type MetaApiResponse = {
+  data: MetaAdRecord[];
+  paging?: {
+    cursors?: {
+      before?: string;
+      after?: string;
+    };
+    next?: string; // token-bearing URL — never logged raw
+  };
+  error?: {
+    message: string;
+    type?: string;
+    code: number;
+    fbtrace_id?: string;
+  };
+};
+
+/**
+ * Runtime configuration for the Meta fetch client.
+ * Built from environment variables — never hardcoded.
+ */
+export type MetaFetchConfig = {
+  /** META_ADLIB_TOKEN — absent or empty triggers simulation mode */
+  token: string | undefined;
+  /** search_terms passed to the API */
+  searchTerms: string;
+  /** ISO country codes, e.g. ['SG'] */
+  countries: string[];
+  /** ad_active_status — 'ALL' | 'ACTIVE' | 'INACTIVE' */
+  adActiveStatus: 'ALL' | 'ACTIVE' | 'INACTIVE';
+  /** Number of ads to fetch per request */
+  limit: number;
+  /** Format used for the whole run — known at query time, not per-record */
+  format: AdFormat;
+  /** When true or token is absent, returns mock data without a network call */
+  simulationMode: boolean;
+};

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev --name init_sqlite",
     "db:seed": "tsx prisma/seed.ts",
-    "verify:runtime": "tsx scripts/verify-runtime.ts"
+    "verify:runtime": "tsx scripts/verify-runtime.ts",
+    "meta:dry-run": "tsx scripts/dry-run-meta-fetch.ts"
   },
   "dependencies": {
+    "@esbuild/linux-x64": "^0.28.0",
     "@prisma/client": "^5.22.0",
     "csv-parse": "^5.5.6",
     "next": "14.2.18",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "meta:dry-run": "tsx scripts/dry-run-meta-fetch.ts"
   },
   "dependencies": {
-    "@esbuild/linux-x64": "^0.28.0",
     "@prisma/client": "^5.22.0",
     "csv-parse": "^5.5.6",
     "next": "14.2.18",

--- a/scripts/dry-run-meta-fetch.ts
+++ b/scripts/dry-run-meta-fetch.ts
@@ -1,0 +1,203 @@
+/**
+ * Phase 4 Step 1 — Meta Fetch Foundation: Dry Run
+ *
+ * Proves the full chain: fetch (or simulate) → normalise → analyse
+ * with ZERO database writes.
+ *
+ * Usage:
+ *   # Simulation mode (no token required):
+ *   npm run meta:dry-run
+ *
+ *   # Live API mode:
+ *   META_ADLIB_TOKEN=<token> npm run meta:dry-run
+ *
+ *   # Override format, search, country:
+ *   META_AD_FORMAT=VIDEO META_SEARCH_TERMS=makeup META_COUNTRIES=SG npm run meta:dry-run
+ *
+ * No Prisma. No database. No schema changes. No UI changes.
+ */
+
+import { analyseAdRow } from '@/lib/analysis';
+import type { AdFormat, AnalysisOutput, ExampleRow } from '@/lib/analysis/types';
+import { buildConfigFromEnv, fetchMetaAds } from '@/lib/providers/meta/fetch';
+import { redactToken, safeLog, safeUrlLabel } from '@/lib/providers/meta/redact';
+import type { MetaAdRecord } from '@/lib/providers/meta/types';
+
+// ─── Normalisation ────────────────────────────────────────────────────────────
+
+function firstOrEmpty(values: string[] | undefined): string {
+  if (!values || values.length === 0) return '';
+  return values[0];
+}
+
+/**
+ * Maps a raw MetaAdRecord to the ExampleRow shape that analyseAdRow() consumes.
+ *
+ * Fields the Meta API provides → mapped:
+ *   ad_creative_bodies[0]            → Copy
+ *   ad_creative_link_titles[0]       → Headline
+ *   ad_creative_link_descriptions[0] → Description
+ *   ad_delivery_start_time           → Active Since
+ *   ad_snapshot_url                  → Ad Link (printed only via safeUrlLabel)
+ *   page_name                        → Product
+ *
+ * Fields the Meta API does NOT provide (human-written analysis) → undefined:
+ *   Analysis, Improvement, Creative Analysis, Creative Improvements
+ *   The analysis pipeline handles their absence with signal-based fallback scoring.
+ */
+function normaliseToExampleRow(record: MetaAdRecord): ExampleRow {
+  return {
+    Product: record.page_name ?? 'Unknown Advertiser',
+    'Ad Link': record.ad_snapshot_url ?? '',
+    Copy: firstOrEmpty(record.ad_creative_bodies),
+    Headline: firstOrEmpty(record.ad_creative_link_titles),
+    Description: firstOrEmpty(record.ad_creative_link_descriptions),
+    'Active Since': record.ad_delivery_start_time ?? '',
+    Analysis: undefined,
+    Improvement: undefined,
+    'Creative Analysis': undefined,
+    'Creative Improvements': undefined,
+    'Other Feedbacks': undefined,
+  };
+}
+
+function deriveAdStatus(record: MetaAdRecord): 'ACTIVE' | 'INACTIVE' {
+  return record.ad_delivery_stop_time ? 'INACTIVE' : 'ACTIVE';
+}
+
+function truncate(str: string, max = 80): string {
+  return str.length > max ? `${str.substring(0, max)}...` : str;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const config = buildConfigFromEnv();
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Phase 4 Step 1 — Meta Fetch Foundation: Dry Run');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  Format:        ${config.format}`);
+  console.log(`  Search terms:  ${config.searchTerms}`);
+  console.log(`  Countries:     ${config.countries.join(', ')}`);
+  console.log(`  Limit:         ${config.limit}`);
+
+  // ── Step 1: Fetch ──────────────────────────────────────────────────────────
+  const records = await fetchMetaAds(config);
+
+  // ── Step 2: Normalise + Analyse ────────────────────────────────────────────
+  type RunResult = {
+    record: MetaAdRecord;
+    row: ExampleRow;
+    analysis: AnalysisOutput;
+  };
+
+  const results: RunResult[] = [];
+
+  for (const record of records) {
+    const row = normaliseToExampleRow(record);
+    const analysis = analyseAdRow(row, config.format as AdFormat);
+    results.push({ record, row, analysis });
+  }
+
+  // ── Step 3: Print results (all URL fields go through safeUrlLabel) ─────────
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log('  RESULTS');
+  console.log('═══════════════════════════════════════════════════════════════');
+
+  for (let i = 0; i < results.length; i++) {
+    const { record, row, analysis } = results[i];
+
+    console.log(`\n─── Ad ${i + 1} of ${results.length} ────────────────────────────────`);
+    console.log(`  Advertiser:   ${record.page_name ?? 'Unknown'}`);
+    console.log(`  Ad status:    ${deriveAdStatus(record)}`);
+    console.log(`  Platforms:    ${record.publisher_platforms?.join(', ') ?? 'N/A'}`);
+    console.log(`  Start date:   ${record.ad_delivery_start_time ?? 'N/A'}`);
+    console.log(`  Stop date:    ${record.ad_delivery_stop_time ?? 'still running'}`);
+    // ad_snapshot_url goes through safeUrlLabel — never printed raw if token present
+    safeLog('  Snapshot URL: ', record.ad_snapshot_url);
+
+    console.log('');
+    console.log('  Normalised ExampleRow:');
+    console.log(`    Product:     ${row.Product}`);
+    console.log(`    Headline:    ${truncate(row.Headline ?? '(empty)')}`);
+    console.log(`    Copy:        ${truncate(row.Copy ?? '(empty)')}`);
+    console.log(`    Description: ${truncate(row.Description ?? '(empty)')}`);
+    // Ad Link also goes through safeUrlLabel
+    console.log(`    Ad Link:     ${safeUrlLabel(row['Ad Link'])}`);
+    console.log(`    Active Since:${row['Active Since'] ?? '(empty)'}`);
+
+    console.log('');
+    console.log('  Analysis output:');
+    console.log(`    Overall score:  ${analysis.overallScore.toFixed(1)} / 10`);
+    console.log(`    Qualified:      ${analysis.qualified ? 'YES ✓' : 'NO'} (threshold: 7.0)`);
+    console.log(`    Final verdict:  ${analysis.finalVerdict}`);
+    console.log(`    Funnel stage:   ${analysis.funnelStage}`);
+    console.log(`    RACE stage:     ${analysis.raceStage}`);
+    console.log(`    Trust funnel:   ${analysis.trustFunnelStage}`);
+    console.log('');
+    console.log('    Phase 3.5 component scores:');
+    console.log(`      Copy:        ${analysis.copyScore.toFixed(1)}`);
+    console.log(`      Headline:    ${analysis.headlineScore !== null ? analysis.headlineScore.toFixed(1) : 'N/A (not provided)'}`);
+    console.log(`      Description: ${analysis.descriptionScore !== null ? analysis.descriptionScore.toFixed(1) : 'N/A (not provided)'}`);
+    console.log(`      Creative:    ${analysis.creativeScore.toFixed(1)}`);
+    console.log(`      Clarity:     ${analysis.clarityScore.toFixed(1)}`);
+    console.log(`      Connection:  ${analysis.connectionScore.toFixed(1)}`);
+    console.log(`      Conviction:  ${analysis.convictionScore.toFixed(1)}`);
+    console.log('');
+    console.log('    AIDA scores:');
+    console.log(`      Attention:   ${analysis.aidaScores.attention.toFixed(1)}`);
+    console.log(`      Interest:    ${analysis.aidaScores.interest.toFixed(1)}`);
+    console.log(`      Desire:      ${analysis.aidaScores.desire.toFixed(1)}`);
+    console.log(`      Action:      ${analysis.aidaScores.action.toFixed(1)}`);
+    console.log('');
+
+    const activeTriggers = analysis.behaviouralTriggers.filter((t) => t.strength !== 'MISSING');
+    if (activeTriggers.length > 0) {
+      console.log(`    Behavioural triggers: ${activeTriggers.map((t) => `${t.name} (${t.strength})`).join(', ')}`);
+    } else {
+      console.log('    Behavioural triggers: none detected');
+    }
+
+    console.log(`    Strengths:    ${analysis.strengths.join(' | ')}`);
+  }
+
+  // ── Step 4: Summary ────────────────────────────────────────────────────────
+  const qualifiedCount = results.filter((r) => r.analysis.qualified).length;
+  const avgScore = results.length > 0
+    ? results.reduce((sum, r) => sum + r.analysis.overallScore, 0) / results.length
+    : 0;
+
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log('  DRY RUN SUMMARY');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  Format used:        ${config.format}`);
+  console.log(`  Ads fetched:        ${records.length}`);
+  console.log(`  Ads normalised:     ${results.length}`);
+  console.log(`  Ads analysed:       ${results.length}`);
+  console.log(`  Qualified (≥7.0):   ${qualifiedCount} of ${results.length}`);
+  console.log(`  Average score:      ${avgScore.toFixed(1)} / 10`);
+  console.log(`  Written to DB:      0`);
+  console.log('');
+
+  if (!config.token && !config.simulationMode) {
+    console.log('  ⚠  SIMULATION MODE — set META_ADLIB_TOKEN to test live API fetch.');
+  } else if (config.token) {
+    console.log('  ✓  LIVE API MODE — real Meta Ad Library data fetched.');
+  } else {
+    console.log('  ⚠  SIMULATION MODE — META_SIMULATION_MODE=true forced simulation.');
+  }
+
+  console.log('');
+  console.log('  Chain proven:');
+  console.log('    fetchMetaAds() → normaliseToExampleRow() → analyseAdRow()');
+  console.log('    No Prisma client instantiated. No DB writes. No schema changes.');
+  console.log('═══════════════════════════════════════════════════════════════');
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  // Redact token from error messages before printing
+  console.error('\n❌ Dry run failed:', redactToken(message));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds Phase 4 Step 1: a token-safe Meta Ad Library dry-run foundation.

## What changed
- Added Meta provider types, fetcher, and redaction helpers under `lib/providers/meta/`.
- Added `scripts/dry-run-meta-fetch.ts` to prove fetch → normalise → analyse without DB writes.
- Added `meta:dry-run` script to `package.json`.
- Documented Meta Ad Library env variables in `.env.example`.

## Verification
Passed locally:
- `npm run meta:dry-run` with a real `META_ADLIB_TOKEN`
- `npm run verify:runtime`
- `npm run build`

Live dry run confirmed:
- 5 real Meta ads fetched
- 5 ads normalised
- 5 ads analysed
- 0 records written to DB
- Token redaction worked: `access_token=REDACTED`
- `ad_snapshot_url` and `Ad Link` were shown only as `present (token redacted)`
- Pagination was detected but not followed, as intended for Step 1

## Notes
- No UI changes.
- No DB writes.
- No schema changes.
- No scheduled scans.
- No live ingestion/persistence workflow.
- No raw token, raw `ad_snapshot_url`, or raw `paging.next` is logged.