### PR TITLE
Fix Meta duplicate lifecycle updates

### DIFF
--- a/lib/ingestion/metaIngestion.ts
+++ b/lib/ingestion/metaIngestion.ts
@@ -197,14 +197,22 @@ export async function ingestMetaAds(
       continue;
     }
 
-    // Deduplication: skip if this metaAdId already exists
+    // Deduplication: update lifecycle fields and record as SEEN — no reinsert
     const existing = await prisma.ad.findUnique({ where: { metaAdId } });
     if (existing) {
-      console.log(`  → Duplicate (skipping insert): ${metaAdId}`);
-      // Still record that this ad was seen in this scan
+      // Update lastSeenAt and adStatus to reflect current fetch state
+      await prisma.ad.update({
+        where: { id: existing.id },
+        data: {
+          lastSeenAt: new Date(),
+          adStatus,
+        },
+      });
+      // Record that this ad was seen in this scan
       await prisma.adScanRecord.create({
         data: { adId: existing.id, scanRunId: scanRun.id, action: 'SEEN' },
       });
+      console.log(`  → Updated lifecycle (SEEN): ${metaAdId} | adStatus: ${adStatus}`);
       skipped++;
       continue;
     }


### PR DESCRIPTION
## Summary
Fixes duplicate Meta ad handling in the Phase 4 Step 2 ingestion pipeline.

## What changed
When an existing `metaAdId` is fetched again, the ingestion pipeline now updates:
- `lastSeenAt`
- `adStatus`

It still creates an `AdScanRecord` with action `SEEN`.

## What did not change
- No reinsert for duplicate ads
- No new `AdAnalysis` for duplicates
- No UI changes
- No schema changes
- No scheduler changes
- No scoring changes

## Verification
Please verify locally if not already run:
- `npx prisma generate`
- `npm run verify:runtime`
- `npm run build`