### PR TITLE
Phase 4 Step 3: Add Meta review workflow

### DIFF
--- a/app/api/ads/[id]/review/route.ts
+++ b/app/api/ads/[id]/review/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/ads/[id]/review
+ *
+ * Approve or reject a pending Meta ad.
+ *
+ * Approval rules (enforced server-side — score is read from the database,
+ * never trusted from the request body):
+ *
+ *   APPROVE + score >= 7.0  →  reviewStatus='APPROVED', qualified=true
+ *   APPROVE + score <  7.0  →  reviewStatus='APPROVED', qualified=false
+ *   REJECT                  →  reviewStatus='REJECTED',  qualified=false
+ *
+ * Rejected ads stay in the database for deduplication and scan history.
+ * This route never touches adLink — no token exposure risk.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+
+const VALID_ACTIONS = ['APPROVE', 'REJECT'] as const;
+type ReviewAction = (typeof VALID_ACTIONS)[number];
+
+function isValidAction(value: unknown): value is ReviewAction {
+  return typeof value === 'string' && (VALID_ACTIONS as readonly string[]).includes(value);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const adId = params.id;
+
+  // Parse action from form body or JSON
+  let action: unknown;
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const formData = await request.formData();
+    action = formData.get('action');
+  } else {
+    try {
+      const body = await request.json() as { action?: unknown };
+      action = body.action;
+    } catch {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+  }
+
+  if (!isValidAction(action)) {
+    return NextResponse.json(
+      { error: `Invalid action. Must be one of: ${VALID_ACTIONS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  // Load the ad — score is read from DB, never from the request
+  const ad = await db.ad.findUnique({
+    where: { id: adId },
+    select: { id: true, adSource: true, reviewStatus: true, score: true },
+  });
+
+  if (!ad) {
+    return NextResponse.json({ error: 'Ad not found' }, { status: 404 });
+  }
+
+  // Only Meta API ads in PENDING state are reviewable via this route
+  if (ad.adSource !== 'meta_api') {
+    return NextResponse.json(
+      { error: 'Only Meta API ads can be reviewed via this route' },
+      { status: 422 },
+    );
+  }
+
+  if (ad.reviewStatus !== 'PENDING') {
+    return NextResponse.json(
+      { error: `Ad is already ${ad.reviewStatus}. Only PENDING ads can be reviewed.` },
+      { status: 422 },
+    );
+  }
+
+  // Apply the review decision
+  if (action === 'APPROVE') {
+    // Score >= 7.0: promote to qualified library
+    // Score <  7.0: approved for tracking only, not added to library
+    const qualified = ad.score >= 7.0;
+    await db.ad.update({
+      where: { id: adId },
+      data: { reviewStatus: 'APPROVED', qualified },
+    });
+  } else {
+    // REJECT: keep record for deduplication and scan history
+    await db.ad.update({
+      where: { id: adId },
+      data: { reviewStatus: 'REJECTED', qualified: false },
+    });
+  }
+
+  // Redirect back to the review queue, preserving any competitorId filter
+  const referer = request.headers.get('referer') ?? '/meta-review';
+  const redirectUrl = referer.includes('/meta-review') ? referer : '/meta-review';
+
+  return NextResponse.redirect(new URL(redirectUrl, request.url));
+}

--- a/app/competitors/[id]/page.tsx
+++ b/app/competitors/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getCompetitorById, getCompetitorWithScanHistory } from '@/lib/queries/competitors';
+import { getPendingAdCount } from '@/lib/queries/pendingAds';
 
 function formatDate(date: Date | string | null | undefined): string {
   if (!date) return 'N/A';
@@ -18,9 +19,10 @@ export default async function CompetitorDetailPage({
 }: {
   params: { id: string };
 }) {
-  const [competitor, competitorWithScans] = await Promise.all([
+  const [competitor, competitorWithScans, pendingAdCount] = await Promise.all([
     getCompetitorById(params.id),
     getCompetitorWithScanHistory(params.id),
+    getPendingAdCount(params.id),
   ]);
 
   if (!competitor) {
@@ -60,6 +62,22 @@ export default async function CompetitorDetailPage({
         <p>Qualified ads: {competitor.ads.length}</p>
         <p>Scan runs: {competitor._count.scanRuns}</p>
       </div>
+
+      {pendingAdCount > 0 && (
+        <div className="card">
+          <h2>Pending Meta ads</h2>
+          <p>
+            <strong>{pendingAdCount}</strong> ad
+            {pendingAdCount !== 1 ? 's' : ''} discovered via the Meta Ad Library
+            API {pendingAdCount !== 1 ? 'are' : 'is'} awaiting review.
+          </p>
+          <p>
+            <Link href={`/meta-review?competitorId=${competitor.id}`}>
+              Review pending ads →
+            </Link>
+          </p>
+        </div>
+      )}
 
       <div className="card">
         <h2>Recent qualified ads</h2>

--- a/app/meta-review/page.tsx
+++ b/app/meta-review/page.tsx
@@ -1,0 +1,224 @@
+/**
+ * /meta-review
+ *
+ * Review queue for Meta API-discovered ads.
+ * Shows only ads where adSource='meta_api' AND reviewStatus='PENDING'.
+ *
+ * Supports optional competitorId filtering:
+ *   /meta-review?competitorId=xxx
+ *
+ * Token safety:
+ *   adLink is never rendered as a raw href — it goes through safeUrlLabel()
+ *   first. If a token is present the field shows as plain text only.
+ *   No other URL fields are rendered.
+ */
+
+import Link from 'next/link';
+import { getPendingAds } from '@/lib/queries/pendingAds';
+import { safeUrlLabel } from '@/lib/providers/meta/redact';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function formatDate(date: Date | string | null | undefined): string {
+  if (!date) return 'N/A';
+  return new Date(date).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function truncate(str: string | null | undefined, max = 160): string {
+  if (!str) return '—';
+  return str.length > max ? `${str.substring(0, max)}…` : str;
+}
+
+function fmt(score: number | null | undefined): string {
+  if (score === null || score === undefined) return 'N/A';
+  return score.toFixed(1);
+}
+
+const VERDICT_LABELS: Record<string, string> = {
+  STRONG_READY_TO_TEST: '✅ Strong — ready to test',
+  GOOD_NEEDS_SHARPENING: '🟡 Good — needs sharpening',
+  CLEAR_IDEA_WEAK_SIGNALS: '🟠 Clear idea — weak signals',
+  TOO_VAGUE_MAJOR_REWORK: '🔴 Too vague — major rework',
+  INSUFFICIENT_INFORMATION: '⚪ Insufficient information',
+};
+
+// ─── page ────────────────────────────────────────────────────────────────────
+
+export default async function MetaReviewPage({
+  searchParams,
+}: {
+  searchParams: { competitorId?: string };
+}) {
+  const competitorId = searchParams.competitorId?.trim() || undefined;
+  const ads = await getPendingAds({ competitorId });
+
+  const pageTitle = competitorId
+    ? `Pending Meta ads — competitor filter active`
+    : 'Pending Meta ads';
+
+  return (
+    <section>
+      <p>
+        <Link href="/">← Dashboard</Link>
+        {' | '}
+        <Link href="/competitors">Competitors</Link>
+      </p>
+
+      <h1>{pageTitle}</h1>
+
+      {competitorId && (
+        <p>
+          Filtering by competitor ID: <code>{competitorId}</code>{' '}
+          <Link href="/meta-review">Clear filter</Link>
+        </p>
+      )}
+
+      <div className="card">
+        <p>
+          <strong>Pending ads:</strong> {ads.length}
+        </p>
+        <p>
+          These ads were discovered via the Meta Ad Library API. They are stored
+          as discovered activity and are not yet part of the qualified library.
+          Review each ad and approve or reject it.
+        </p>
+        <p>
+          <strong>Approve (score ≥ 7.0):</strong> promotes to qualified library.
+          <br />
+          <strong>Approve (score &lt; 7.0):</strong> acknowledged for tracking
+          only — does not enter the library.
+          <br />
+          <strong>Reject:</strong> removes from queue, keeps record for scan
+          history.
+        </p>
+      </div>
+
+      {ads.length === 0 ? (
+        <div className="card">
+          <p>No pending Meta ads{competitorId ? ' for this competitor' : ''}.</p>
+          <p>
+            Run <code>npm run meta:ingest</code> to fetch new ads from the Meta
+            Ad Library.
+          </p>
+        </div>
+      ) : (
+        ads.map((ad) => {
+          const a = ad.analysis;
+          const verdict = a?.finalVerdict
+            ? (VERDICT_LABELS[a.finalVerdict] ?? a.finalVerdict)
+            : '—';
+
+          // Token safety: never render adLink as a raw href
+          const adLinkLabel = safeUrlLabel(ad.adLink);
+          const adLinkIsSafe =
+            ad.adLink &&
+            adLinkLabel !== 'N/A' &&
+            adLinkLabel !== 'present (token redacted)';
+
+          return (
+            <div className="card" key={ad.id}>
+              {/* ── Identity ── */}
+              <p>
+                <strong>{ad.competitor.name}</strong>
+                {' · '}
+                {ad.adFormat}
+                {' · '}
+                <strong>Score: {ad.score.toFixed(1)} / 10</strong>
+                {ad.score >= 7.0 && (
+                  <span> · 🔑 qualifies for library on approval</span>
+                )}
+              </p>
+              <p>
+                <strong>Verdict:</strong> {verdict}
+              </p>
+
+              {/* ── Content ── */}
+              {ad.headline && (
+                <p>
+                  <strong>Headline:</strong> {ad.headline}
+                </p>
+              )}
+              {ad.primaryCopy && (
+                <p>
+                  <strong>Copy:</strong> {truncate(ad.primaryCopy)}
+                </p>
+              )}
+              {ad.description && (
+                <p>
+                  <strong>Description:</strong> {truncate(ad.description)}
+                </p>
+              )}
+
+              {/* ── Component scores ── */}
+              {a && (
+                <p>
+                  <strong>Component scores:</strong>{' '}
+                  Copy {fmt(a.copyScore)}
+                  {' · '}
+                  Headline {fmt(a.headlineScore)}
+                  {' · '}
+                  Desc {fmt(a.descriptionScore)}
+                </p>
+              )}
+
+              {/* ── Metadata ── */}
+              <p>
+                <strong>Ad status:</strong> {ad.adStatus}
+                {' · '}
+                <strong>First seen:</strong> {formatDate(ad.firstSeenAt)}
+                {' · '}
+                <strong>Last seen:</strong> {formatDate(ad.lastSeenAt)}
+              </p>
+
+              {/* ── External link — token-safe ── */}
+              <p>
+                <strong>Ad link:</strong>{' '}
+                {adLinkIsSafe ? (
+                  <a href={ad.adLink!} target="_blank" rel="noreferrer noopener">
+                    Open ad ↗
+                  </a>
+                ) : (
+                  <span>{adLinkLabel}</span>
+                )}
+              </p>
+
+              {/* ── Review actions ── */}
+              <p>
+                <form
+                  method="POST"
+                  action={`/api/ads/${ad.id}/review`}
+                  style={{ display: 'inline' }}
+                >
+                  <input type="hidden" name="action" value="APPROVE" />
+                  <button type="submit">
+                    {ad.score >= 7.0 ? 'Approve → Add to library' : 'Approve (tracking only)'}
+                  </button>
+                </form>
+                {'  '}
+                <form
+                  method="POST"
+                  action={`/api/ads/${ad.id}/review`}
+                  style={{ display: 'inline' }}
+                >
+                  <input type="hidden" name="action" value="REJECT" />
+                  <button type="submit">Reject</button>
+                </form>
+              </p>
+
+              {/* ── Meta ID (for audit / debugging) ── */}
+              {ad.metaAdId && (
+                <p style={{ fontSize: '0.85em', color: '#666' }}>
+                  Meta Ad ID: {ad.metaAdId}
+                </p>
+              )}
+            </div>
+          );
+        })
+      )}
+    </section>
+  );
+}

--- a/lib/queries/pendingAds.ts
+++ b/lib/queries/pendingAds.ts
@@ -1,0 +1,59 @@
+/**
+ * Queries for the Meta ad review workflow.
+ *
+ * Intentionally isolated from lib/queries/ads.ts so that pending-ad logic
+ * never bleeds into the qualified library queries.
+ *
+ * All functions here target:
+ *   adSource = 'meta_api'
+ *   reviewStatus = 'PENDING'
+ *
+ * These ads are discovered activity — not curated library entries.
+ */
+
+import { db } from '@/lib/db';
+
+export type PendingAdsFilter = {
+  competitorId?: string;
+};
+
+/**
+ * Returns all pending Meta ads for the review queue.
+ * Ordered by score descending so high-potential ads surface first.
+ */
+export function getPendingAds(filter: PendingAdsFilter = {}) {
+  return db.ad.findMany({
+    where: {
+      adSource: 'meta_api',
+      reviewStatus: 'PENDING',
+      ...(filter.competitorId ? { competitorId: filter.competitorId } : {}),
+    },
+    include: {
+      competitor: { select: { id: true, name: true } },
+      analysis: {
+        select: {
+          overallScore: true,
+          finalVerdict: true,
+          copyScore: true,
+          headlineScore: true,
+          descriptionScore: true,
+        },
+      },
+    },
+    orderBy: { score: 'desc' },
+  });
+}
+
+/**
+ * Returns the count of pending Meta ads for a specific competitor.
+ * Used on the competitor detail page to surface the review queue link.
+ */
+export function getPendingAdCount(competitorId: string): Promise<number> {
+  return db.ad.count({
+    where: {
+      adSource: 'meta_api',
+      reviewStatus: 'PENDING',
+      competitorId,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Adds Phase 4 Step 3: a lightweight review workflow for Meta API-discovered ads.

## What changed
- Added `lib/queries/pendingAds.ts` to query pending Meta API ads.
- Added `/meta-review` page for reviewing `PENDING` Meta ads.
- Added `POST /api/ads/[id]/review` for approve/reject actions.
- Updated competitor detail pages with a pending Meta ads count/link.

## Behaviour
- Pending Meta ads remain separate from the qualified library.
- The review queue only shows `adSource = 'meta_api'` and `reviewStatus = 'PENDING'` ads.
- Approving an ad with score >= 7.0 sets `reviewStatus = 'APPROVED'` and `qualified = true`.
- Approving an ad with score < 7.0 sets `reviewStatus = 'APPROVED'` and keeps `qualified = false`.
- Rejecting an ad sets `reviewStatus = 'REJECTED'` and keeps `qualified = false`.
- Score is read from the database in the review route, not from the POST body.
- Token-bearing ad links are not rendered as clickable URLs on the review page.

## Verification
Passed locally:
- `npx prisma generate`
- `npm run verify:runtime`
- `npm run build`

Build confirmed the new routes:
- `/meta-review`
- `/api/ads/[id]/review`

## Notes
- No schema changes.
- No scoring changes.
- No scheduled scans.
- No visual preview implementation.
- No changes to the qualified ad detail gate.
- Pending/rejected ads remain hidden from existing qualified library pages.