### PR TITLE
Phase 4 Step 4: competitor Meta config management

### DIFF
--- a/app/api/competitors/[id]/meta-config/route.ts
+++ b/app/api/competitors/[id]/meta-config/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import {
+  findMetaPageIdConflict,
+  updateCompetitorMetaConfig,
+  type MetaConfigUpdate,
+} from '@/lib/queries/competitors';
+
+const FACEBOOK_URL_PATTERN = /^https:\/\/(www\.)?facebook\.com\//i;
+const META_PAGE_ID_PATTERN = /^\d+$/;
+const META_PAGE_ID_MAX_LENGTH = 20;
+
+type MetaConfigBody = {
+  facebookPageUrl?: unknown;
+  metaPageId?: unknown;
+};
+
+function normaliseOptionalString(value: unknown, fieldName: string): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function validateFacebookPageUrl(value: string | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  if (!FACEBOOK_URL_PATTERN.test(value)) {
+    throw new Error(
+      `facebookPageUrl must start with https://www.facebook.com/ or https://facebook.com/. Received: ${value}`,
+    );
+  }
+  return value;
+}
+
+function validateMetaPageId(value: string | null | undefined): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  if (!META_PAGE_ID_PATTERN.test(value)) {
+    throw new Error('metaPageId must contain digits only.');
+  }
+  if (value.length > META_PAGE_ID_MAX_LENGTH) {
+    throw new Error(`metaPageId must be ${META_PAGE_ID_MAX_LENGTH} characters or fewer.`);
+  }
+  return value;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const body = (await request.json()) as MetaConfigBody;
+
+    const facebookPageUrl = validateFacebookPageUrl(
+      normaliseOptionalString(body.facebookPageUrl, 'facebookPageUrl'),
+    );
+    const metaPageId = validateMetaPageId(
+      normaliseOptionalString(body.metaPageId, 'metaPageId'),
+    );
+
+    const data: MetaConfigUpdate = {};
+    if (facebookPageUrl !== undefined) data.facebookPageUrl = facebookPageUrl;
+    if (metaPageId !== undefined) data.metaPageId = metaPageId;
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { error: 'Provide facebookPageUrl or metaPageId to update.' },
+        { status: 400 },
+      );
+    }
+
+    if (data.metaPageId) {
+      const conflict = await findMetaPageIdConflict(data.metaPageId, params.id);
+      if (conflict) {
+        return NextResponse.json(
+          { error: `Meta Page ID is already assigned to competitor ${conflict.name}.` },
+          { status: 400 },
+        );
+      }
+    }
+
+    const updatedCompetitor = await updateCompetitorMetaConfig(params.id, data);
+
+    return NextResponse.json({ competitor: updatedCompetitor });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return NextResponse.json({ error: 'Competitor not found.' }, { status: 404 });
+    }
+
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+    }
+
+    const message = error instanceof Error ? error.message : 'Unable to update competitor Meta configuration.';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/competitors/[id]/page.tsx
+++ b/app/competitors/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import CompetitorMetaConfigForm from '@/app/components/CompetitorMetaConfigForm';
 import { getCompetitorById, getCompetitorWithScanHistory } from '@/lib/queries/competitors';
 import { getPendingAdCount } from '@/lib/queries/pendingAds';
 
@@ -12,6 +13,27 @@ function formatDate(date: Date | string | null | undefined): string {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+function getMetaReadiness(metaPageId: string | null, lastScannedAt: Date | null) {
+  if (!metaPageId) {
+    return {
+      label: 'Not ready - Meta page ID missing',
+      detail: 'Add a Meta Page ID below to enable competitor-specific Meta ingestion.',
+    };
+  }
+
+  if (!lastScannedAt) {
+    return {
+      label: 'Ready - not yet scanned',
+      detail: 'This competitor has a Meta Page ID and is ready for its first Meta ingestion run.',
+    };
+  }
+
+  return {
+    label: 'Ready - previously scanned',
+    detail: `This competitor has a Meta Page ID and was last scanned on ${formatDate(lastScannedAt)}.`,
+  };
 }
 
 export default async function CompetitorDetailPage({
@@ -30,6 +52,7 @@ export default async function CompetitorDetailPage({
   }
 
   const scanRuns = competitorWithScans?.scanRuns ?? [];
+  const metaReadiness = getMetaReadiness(competitor.metaPageId, competitor.lastScannedAt);
 
   return (
     <section>
@@ -45,15 +68,38 @@ export default async function CompetitorDetailPage({
         <p><strong>Industry:</strong> {competitor.industry.name}</p>
         <p><strong>Status:</strong> {competitor.status}</p>
         <p><strong>Discovery source:</strong> {competitor.discoverySource}</p>
-        {competitor.facebookPageUrl && (
-          <p>
-            <strong>Facebook page:</strong>{' '}
+        <p>
+          <strong>Facebook page:</strong>{' '}
+          {competitor.facebookPageUrl ? (
             <a href={competitor.facebookPageUrl} target="_blank" rel="noreferrer">
               {competitor.facebookPageUrl}
             </a>
+          ) : (
+            'Not set'
+          )}
+        </p>
+        <p>
+          <strong>Meta Page ID:</strong>{' '}
+          {competitor.metaPageId ? <code>{competitor.metaPageId}</code> : 'Not set'}
+        </p>
+        <p><strong>Readiness:</strong> {metaReadiness.label}</p>
+        <p><strong>Last scanned:</strong> {formatDate(competitor.lastScannedAt)}</p>
+      </div>
+
+      <div className="card">
+        <h2>Meta configuration</h2>
+        <p>{metaReadiness.detail}</p>
+        {competitor.metaPageId && (
+          <p>
+            Ingestion command:{' '}
+            <code>COMPETITOR_ID={competitor.id} npm run meta:ingest</code>
           </p>
         )}
-        <p><strong>Last scanned:</strong> {formatDate(competitor.lastScannedAt)}</p>
+        <CompetitorMetaConfigForm
+          competitorId={competitor.id}
+          facebookPageUrl={competitor.facebookPageUrl}
+          metaPageId={competitor.metaPageId}
+        />
       </div>
 
       <div className="card">
@@ -73,7 +119,7 @@ export default async function CompetitorDetailPage({
           </p>
           <p>
             <Link href={`/meta-review?competitorId=${competitor.id}`}>
-              Review pending ads →
+              Review pending ads
             </Link>
           </p>
         </div>

--- a/app/competitors/page.tsx
+++ b/app/competitors/page.tsx
@@ -10,6 +10,12 @@ function formatDate(date: Date | null | undefined): string {
   });
 }
 
+function getMetaReadinessLabel(metaPageId: string | null, lastScannedAt: Date | null): string {
+  if (!metaPageId) return 'No page ID';
+  if (!lastScannedAt) return 'Meta ready - not yet scanned';
+  return 'Meta ready - previously scanned';
+}
+
 export default async function CompetitorsPage() {
   const competitors = await getCompetitors();
 
@@ -35,6 +41,7 @@ export default async function CompetitorsPage() {
             <p>Client: {competitor.client.name}</p>
             <p>Industry: {competitor.industry.name}</p>
             <p>Status: {competitor.status}</p>
+            <p>Meta readiness: {getMetaReadinessLabel(competitor.metaPageId, competitor.lastScannedAt)}</p>
             <p>Ads: {competitor._count.ads}</p>
             <p>Scan runs: {competitor._count.scanRuns}</p>
             <p>Last scanned: {formatDate(competitor.lastScannedAt)}</p>

--- a/app/components/CompetitorMetaConfigForm.tsx
+++ b/app/components/CompetitorMetaConfigForm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+
+type CompetitorMetaConfigFormProps = {
+  competitorId: string;
+  facebookPageUrl: string | null;
+  metaPageId: string | null;
+};
+
+export default function CompetitorMetaConfigForm({
+  competitorId,
+  facebookPageUrl,
+  metaPageId,
+}: CompetitorMetaConfigFormProps) {
+  const [facebookUrlValue, setFacebookUrlValue] = useState(facebookPageUrl ?? '');
+  const [metaPageIdValue, setMetaPageIdValue] = useState(metaPageId ?? '');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSaving(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch(`/api/competitors/${competitorId}/meta-config`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          facebookPageUrl: facebookUrlValue,
+          metaPageId: metaPageIdValue,
+        }),
+      });
+
+      const payload = (await response.json()) as { error?: string };
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Unable to save Meta configuration.');
+      }
+
+      setStatusMessage('Meta configuration saved. Refreshing page...');
+      window.location.reload();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to save Meta configuration.';
+      setErrorMessage(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div style={{ marginBottom: '12px' }}>
+        <label htmlFor="facebookPageUrl">
+          <strong>Facebook page URL</strong>
+        </label>
+        <div style={{ marginTop: '8px' }}>
+          <input
+            id="facebookPageUrl"
+            name="facebookPageUrl"
+            type="url"
+            value={facebookUrlValue}
+            onChange={(event) => setFacebookUrlValue(event.target.value)}
+            placeholder="https://www.facebook.com/brand"
+            style={{ minWidth: '320px', padding: '8px' }}
+          />
+        </div>
+      </div>
+
+      <div style={{ marginBottom: '12px' }}>
+        <label htmlFor="metaPageId">
+          <strong>Meta Page ID</strong>
+        </label>
+        <div style={{ marginTop: '8px' }}>
+          <input
+            id="metaPageId"
+            name="metaPageId"
+            type="text"
+            inputMode="numeric"
+            value={metaPageIdValue}
+            onChange={(event) => setMetaPageIdValue(event.target.value)}
+            placeholder="100001234567890"
+            style={{ minWidth: '320px', padding: '8px' }}
+          />
+        </div>
+      </div>
+
+      <button type="submit" disabled={isSaving} style={{ padding: '8px 12px' }}>
+        {isSaving ? 'Saving...' : 'Save Meta configuration'}
+      </button>
+
+      {statusMessage && <p style={{ color: 'green' }}>{statusMessage}</p>}
+      {errorMessage && <p style={{ color: 'crimson' }}>{errorMessage}</p>}
+    </form>
+  );
+}

--- a/lib/queries/competitors.ts
+++ b/lib/queries/competitors.ts
@@ -9,6 +9,11 @@ export type CompetitorsFilter = {
   offset?: number;
 };
 
+export type MetaConfigUpdate = {
+  facebookPageUrl?: string | null;
+  metaPageId?: string | null;
+};
+
 export function getCompetitors(filter: CompetitorsFilter = {}) {
   const where: Prisma.CompetitorWhereInput = {};
 
@@ -80,5 +85,36 @@ export function getCompetitorsWithQualifiedAds() {
     },
     select: { id: true, name: true },
     orderBy: { name: 'asc' },
+  });
+}
+
+export function findMetaPageIdConflict(metaPageId: string, currentCompetitorId: string) {
+  return db.competitor.findFirst({
+    where: {
+      metaPageId,
+      id: { not: currentCompetitorId },
+    },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+}
+
+export function updateCompetitorMetaConfig(
+  id: string,
+  data: MetaConfigUpdate,
+) {
+  return db.competitor.update({
+    where: { id },
+    data,
+    select: {
+      id: true,
+      name: true,
+      facebookPageUrl: true,
+      metaPageId: true,
+      lastScannedAt: true,
+      updatedAt: true,
+    },
   });
 }


### PR DESCRIPTION
Implements Phase 4 Step 4: competitor Meta page ID management. Adds an API route to update competitor Facebook page URL and Meta Page ID, a client-side edit form, duplicate Meta Page ID validation, Meta readiness labels on the competitors list page, and Meta readiness details on the competitor detail page. No schema, scoring, ingestion, dashboard, or live scanning changes were added. Please verify locally with npm install, npx tsc --noEmit, and npm run dev.