### PR TITLE
Phase 4 Step 5: use Meta Page ID for ingestion

### DIFF
--- a/lib/ingestion/metaIngestion.ts
+++ b/lib/ingestion/metaIngestion.ts
@@ -1,17 +1,18 @@
 /**
- * Phase 4 Step 2 — Meta Ad Ingestion
+ * Phase 4 Step 5 — Meta Ad Ingestion targeted by competitor Meta Page ID
  *
  * Fetches ads from the Meta Ad Library API and writes them to the database as
  * discovered competitor activity. All writes are guarded by the dryRun flag.
  *
  * Design invariants enforced here:
+ *  - competitor.metaPageId is required before any fetch occurs
+ *  - fetchConfig.searchPageIds is forced to [competitor.metaPageId]
  *  - qualified is always false for API-sourced ads (7.0 threshold is not weakened)
  *  - reviewStatus is always 'PENDING' on first insert
  *  - adSource is always 'meta_api'
  *  - adLink is always run through redactToken() before storage
  *  - metaAdId uniqueness is checked before every insert (deduplication)
  *  - Post-write token safety verification queries for any stored access_token= value
- *  - paging.next is consumed by fetchMetaAds() and never reaches this layer
  */
 
 import type { PrismaClient } from '@prisma/client';
@@ -21,32 +22,19 @@ import { fetchMetaAds } from '@/lib/providers/meta/fetch';
 import type { MetaAdRecord, MetaFetchConfig } from '@/lib/providers/meta/types';
 import { redactToken } from '@/lib/providers/meta/redact';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export type IngestionConfig = {
-  /** Prisma cuid of the Competitor whose library this scan targets */
   competitorId: string;
-  /** Meta fetch parameters — built by buildConfigFromEnv() in the calling script */
   fetchConfig: MetaFetchConfig;
-  /**
-   * When true: fetch, normalise, analyse, and print what would be written,
-   * then return without any Prisma writes. Competitor lookup (read) still runs.
-   */
   dryRun: boolean;
 };
 
 export type IngestionResult = {
   adsProcessed: number;
   adsInserted: number;
-  /** Duplicates — metaAdId already exists in the database */
   adsSkipped: number;
-  /** Records with no id field — cannot deduplicate, skipped */
   adsErrored: number;
-  /** null when dryRun is true */
   scanRunId: string | null;
 };
-
-// ─── Internal helpers ─────────────────────────────────────────────────────────
 
 function firstOrEmpty(values: string[] | undefined): string {
   if (!values || values.length === 0) return '';
@@ -79,37 +67,37 @@ function deriveAdStatus(record: MetaAdRecord): string {
   return record.ad_delivery_stop_time ? 'INACTIVE' : 'ACTIVE';
 }
 
-// ─── Public API ───────────────────────────────────────────────────────────────
-
-/**
- * Core ingestion function. Fetches Meta ads, analyses them, and writes to the
- * database under the specified Competitor. Pass dryRun=true to prove the full
- * chain without any database writes.
- *
- * Token safety:
- *  - ad_snapshot_url is run through redactToken() before assignment to adLink
- *  - After all writes, a verification query asserts no stored adLink contains
- *    access_token= — throws with a TOKEN SAFETY VIOLATION message if found
- *  - Error messages from fetch are already redacted by fetchMetaAds()
- */
 export async function ingestMetaAds(
   config: IngestionConfig,
   prisma: PrismaClient,
 ): Promise<IngestionResult> {
   const { competitorId, fetchConfig, dryRun } = config;
 
-  // ── 1. Load Competitor ──────────────────────────────────────────────────────
-  // Always runs — dry-run skips writes, not reads.
   const competitor = await prisma.competitor.findUniqueOrThrow({
     where: { id: competitorId },
-    select: { id: true, name: true, clientId: true, industryId: true },
+    select: {
+      id: true,
+      name: true,
+      clientId: true,
+      industryId: true,
+      metaPageId: true,
+    },
   });
+
+  if (!competitor.metaPageId) {
+    throw new Error(
+      `Competitor "${competitor.name}" has no Meta Page ID configured. ` +
+        'Set it via the competitor config page before running ingestion.',
+    );
+  }
+
+  fetchConfig.searchPageIds = [competitor.metaPageId];
 
   console.log(`\n  Competitor:   ${competitor.name} (${competitor.id})`);
   console.log(`  Client ID:    ${competitor.clientId}`);
   console.log(`  Industry ID:  ${competitor.industryId}`);
+  console.log(`  Meta Page ID: ${competitor.metaPageId}`);
 
-  // ── 2. Fetch ────────────────────────────────────────────────────────────────
   const records = await fetchMetaAds(fetchConfig);
 
   if (records.length === 0) {
@@ -117,7 +105,6 @@ export async function ingestMetaAds(
     return { adsProcessed: 0, adsInserted: 0, adsSkipped: 0, adsErrored: 0, scanRunId: null };
   }
 
-  // ── 3. Normalise + Analyse ──────────────────────────────────────────────────
   type Processed = {
     record: MetaAdRecord;
     row: ExampleRow;
@@ -126,28 +113,29 @@ export async function ingestMetaAds(
     adStatus: string;
   };
 
-  const processed: Processed[] = records.map((record) => ({
-    record,
-    row: normaliseRecord(record),
-    analysis: analyseAdRow(normaliseRecord(record), fetchConfig.format as AdFormat),
-    // Token stripped here — this is the value that will be stored in adLink
-    safeAdLink: record.ad_snapshot_url ? redactToken(record.ad_snapshot_url) : '',
-    adStatus: deriveAdStatus(record),
-  }));
+  const processed: Processed[] = records.map((record) => {
+    const row = normaliseRecord(record);
+    return {
+      record,
+      row,
+      analysis: analyseAdRow(row, fetchConfig.format as AdFormat),
+      safeAdLink: record.ad_snapshot_url ? redactToken(record.ad_snapshot_url) : '',
+      adStatus: deriveAdStatus(record),
+    };
+  });
 
-  // ── 4. Dry-run: print plan and exit ─────────────────────────────────────────
   if (dryRun) {
-    console.log('\n  ── DRY RUN — no DB writes ──────────────────────────────────');
-    console.log(`\n  Would create 1 ScanRun (source: META_API, status: IN_PROGRESS → COMPLETED)`);
+    console.log('\n  DRY RUN - no DB writes');
+    console.log(`  Would create 1 ScanRun (source: META_API, status: IN_PROGRESS to COMPLETED)`);
     console.log(`  Would process ${processed.length} ad record(s):\n`);
 
     for (let i = 0; i < processed.length; i++) {
       const { record, analysis, safeAdLink, adStatus } = processed[i];
-      const metaAdId = record.id ?? `(no id — index ${i})`;
+      const metaAdId = record.id ?? `(no id - index ${i})`;
       const hasId = !!record.id;
 
       console.log(`  [${i + 1}/${processed.length}]`);
-      console.log(`    metaAdId:     ${metaAdId}${hasId ? '' : ' ← WOULD BE SKIPPED (no id)'}`);
+      console.log(`    metaAdId:     ${metaAdId}${hasId ? '' : ' - WOULD BE SKIPPED (no id)'}`);
       console.log(`    advertiser:   ${record.page_name ?? 'Unknown'}`);
       console.log(`    adSource:     meta_api`);
       console.log(`    reviewStatus: PENDING`);
@@ -160,7 +148,6 @@ export async function ingestMetaAds(
     }
 
     console.log('\n  Written to DB: 0');
-    console.log('  ────────────────────────────────────────────────────────────');
 
     return {
       adsProcessed: processed.length,
@@ -171,7 +158,6 @@ export async function ingestMetaAds(
     };
   }
 
-  // ── 5. Create ScanRun ───────────────────────────────────────────────────────
   const scanRun = await prisma.scanRun.create({
     data: {
       competitorId,
@@ -186,21 +172,17 @@ export async function ingestMetaAds(
   let skipped = 0;
   let errored = 0;
 
-  // ── 6. Ingest each record ───────────────────────────────────────────────────
   for (const { record, analysis, safeAdLink, adStatus } of processed) {
     const metaAdId = record.id;
 
-    // Records with no id cannot be deduplicated — skip
     if (!metaAdId) {
-      console.log(`  ⚠  Skipping record with no id (page: ${record.page_name ?? 'unknown'})`);
+      console.log(`  Skipping record with no id (page: ${record.page_name ?? 'unknown'})`);
       errored++;
       continue;
     }
 
-    // Deduplication: update lifecycle fields and record as SEEN — no reinsert
     const existing = await prisma.ad.findUnique({ where: { metaAdId } });
     if (existing) {
-      // Update lastSeenAt and adStatus to reflect current fetch state
       await prisma.ad.update({
         where: { id: existing.id },
         data: {
@@ -208,18 +190,14 @@ export async function ingestMetaAds(
           adStatus,
         },
       });
-      // Record that this ad was seen in this scan
       await prisma.adScanRecord.create({
         data: { adId: existing.id, scanRunId: scanRun.id, action: 'SEEN' },
       });
-      console.log(`  → Updated lifecycle (SEEN): ${metaAdId} | adStatus: ${adStatus}`);
+      console.log(`  Updated lifecycle (SEEN): ${metaAdId} | adStatus: ${adStatus}`);
       skipped++;
       continue;
     }
 
-    // Create Ad
-    // qualified is always false — API-sourced ads enter as discovered activity
-    // reviewStatus='PENDING' — requires human review before promotion to library
     const ad = await prisma.ad.create({
       data: {
         metaAdId,
@@ -229,7 +207,7 @@ export async function ingestMetaAds(
         clientId: competitor.clientId,
         industryId: competitor.industryId,
         adFormat: fetchConfig.format,
-        adLink: safeAdLink,              // token already stripped by redactToken()
+        adLink: safeAdLink,
         productOrService: record.page_name ?? null,
         primaryCopy: firstOrEmpty(record.ad_creative_bodies) || null,
         headline: firstOrEmpty(record.ad_creative_link_titles) || null,
@@ -243,16 +221,13 @@ export async function ingestMetaAds(
       },
     });
 
-    // Create AdAnalysis — all component scores stored even when below 7.0
     await prisma.adAnalysis.create({
       data: {
         adId: ad.id,
-        // Human-written fields are empty for API-sourced ads
         creativeAnalysis: '',
         copyAnalysis: '',
         headlineAnalysis: '',
         descriptionAnalysis: '',
-        // Computed fields
         strengthsJson: JSON.stringify(analysis.strengths),
         weaknessesJson: JSON.stringify(analysis.weaknesses),
         improvementsJson: JSON.stringify(analysis.improvements),
@@ -261,7 +236,6 @@ export async function ingestMetaAds(
         aidaJson: JSON.stringify(analysis.aida),
         funnelStage: analysis.funnelStage,
         raceStage: analysis.raceStage,
-        // Phase 3.5 conversion scoring
         copyScore: analysis.copyScore,
         headlineScore: analysis.headlineScore,
         descriptionScore: analysis.descriptionScore,
@@ -280,13 +254,11 @@ export async function ingestMetaAds(
           ? JSON.stringify(analysis.rewriteDirection)
           : null,
         finalVerdict: analysis.finalVerdict,
-        // Shared sub-scores
         hookStopScrollScore: analysis.subScores.hookStopScroll,
         audienceRelevanceScore: analysis.subScores.audienceRelevance,
         valueClarityScore: analysis.subScores.valueClarity,
         trustProofStrengthScore: analysis.subScores.trustProofStrength,
         ctaClarityScore: analysis.subScores.ctaClarity,
-        // Static-specific sub-scores (null for video)
         visualHierarchyScore: analysis.subScores.visualHierarchy ?? null,
         productClarityScore: analysis.subScores.productClarity ?? null,
         offerClarityScore: analysis.subScores.offerClarity ?? null,
@@ -294,7 +266,6 @@ export async function ingestMetaAds(
         descriptionUsefulnessScore: analysis.subScores.descriptionUsefulness ?? null,
         ctaVisibilityScore: analysis.subScores.ctaVisibility ?? null,
         trustSignalsScore: analysis.subScores.trustSignals ?? null,
-        // Video-specific sub-scores (null for static)
         firstThreeSecondsScore: analysis.subScores.firstThreeSeconds ?? null,
         soundOffDesignScore: analysis.subScores.soundOffDesign ?? null,
         soundOnEnhancementScore: analysis.subScores.soundOnEnhancement ?? null,
@@ -305,18 +276,16 @@ export async function ingestMetaAds(
       },
     });
 
-    // Link Ad to this ScanRun
     await prisma.adScanRecord.create({
       data: { adId: ad.id, scanRunId: scanRun.id, action: 'NEW' },
     });
 
     console.log(
-      `  ✓ Inserted: ${metaAdId} | score: ${analysis.overallScore.toFixed(1)} | verdict: ${analysis.finalVerdict}`,
+      `  Inserted: ${metaAdId} | score: ${analysis.overallScore.toFixed(1)} | verdict: ${analysis.finalVerdict}`,
     );
     inserted++;
   }
 
-  // ── 7. Close ScanRun ────────────────────────────────────────────────────────
   await prisma.scanRun.update({
     where: { id: scanRun.id },
     data: {
@@ -327,15 +296,11 @@ export async function ingestMetaAds(
     },
   });
 
-  // ── 8. Update Competitor.lastScannedAt ──────────────────────────────────────
   await prisma.competitor.update({
     where: { id: competitorId },
     data: { lastScannedAt: new Date() },
   });
 
-  // ── 9. Token safety verification ────────────────────────────────────────────
-  // Query all API-sourced Ads and assert none have a bare access_token= in adLink.
-  // This is a hard post-write invariant — any match means redactToken() was bypassed.
   const leakedTokenAds = await prisma.ad.findMany({
     where: {
       adSource: 'meta_api',
@@ -352,7 +317,7 @@ export async function ingestMetaAds(
     );
   }
 
-  console.log('  ✓ Token safety verified — no access_token= in stored adLink values');
+  console.log('  Token safety verified - no access_token= in stored adLink values');
 
   return {
     adsProcessed: processed.length,

--- a/lib/providers/meta/fetch.ts
+++ b/lib/providers/meta/fetch.ts
@@ -1,4 +1,4 @@
-import { redactToken, safeLog } from '@/lib/providers/meta/redact';
+import { redactToken } from '@/lib/providers/meta/redact';
 import type { MetaAdRecord, MetaApiResponse, MetaFetchConfig } from '@/lib/providers/meta/types';
 
 const META_API_BASE = 'https://graph.facebook.com/v25.0/ads_archive';
@@ -82,6 +82,19 @@ function getSimulatedRecords(): MetaAdRecord[] {
   ];
 }
 
+function filterSimulatedRecords(records: MetaAdRecord[], config: MetaFetchConfig): MetaAdRecord[] {
+  if (!config.searchPageIds || config.searchPageIds.length === 0) return records;
+
+  const pageIdSet = new Set(config.searchPageIds);
+  const filtered = records.filter((record) => record.page_id && pageIdSet.has(record.page_id));
+
+  if (filtered.length === 0) {
+    console.log(`  Simulation note: no mock ads found for page ID(s): ${config.searchPageIds.join(', ')}`);
+  }
+
+  return filtered;
+}
+
 // ─── Live fetch ───────────────────────────────────────────────────────────────
 
 async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
@@ -91,13 +104,17 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
     ad_active_status: config.adActiveStatus,
     fields: FIELDS,
     limit: String(config.limit),
-    access_token: config.token!, // present — checked before calling this function
+    access_token: config.token!,
   });
 
-  // Log the request without the token in the URL
-  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
-  console.log(`\n  Fetching from Meta Ad Library API...`);
-  console.log(`  Search terms:  ${config.searchTerms}`);
+  if (config.searchPageIds && config.searchPageIds.length > 0) {
+    params.set('search_page_ids', JSON.stringify(config.searchPageIds));
+  }
+
+  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds?.join(',') ?? ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
+  console.log('\n  Fetching from Meta Ad Library API...');
+  console.log(`  Search terms:  ${config.searchTerms || '(empty)'}`);
+  console.log(`  Page IDs:      ${config.searchPageIds?.join(', ') ?? '(not set)'}`);
   console.log(`  Countries:     ${config.countries.join(', ')}`);
   console.log(`  Active status: ${config.adActiveStatus}`);
   console.log(`  Limit:         ${config.limit}`);
@@ -108,7 +125,6 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
   const json = (await response.json()) as MetaApiResponse;
 
   if (json.error) {
-    // Redact token from error messages before throwing
     const safeMessage = redactToken(
       `Meta API error (code ${json.error.code}): ${json.error.message}`,
     );
@@ -116,15 +132,13 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
   }
 
   if (!json.data || json.data.length === 0) {
-    throw new Error('Meta API returned no ads for this search. Try a different search_terms or country.');
+    throw new Error('Meta API returned no ads for this page ID or search. Try a different Meta Page ID, search_terms, or country.');
   }
 
   console.log(`  ✓ Received ${json.data.length} ad(s)`);
 
-  // paging.next is a token-bearing URL — log only whether pagination exists,
-  // never the URL itself. Step 1 does not follow pagination.
   if (json.paging?.next) {
-    console.log(`  ℹ  Pagination available — not followed in Step 1 (single page only)`);
+    console.log('  ℹ  Pagination available — not followed in this step (single page only)');
   }
 
   return json.data;
@@ -132,46 +146,25 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-/**
- * Fetches ads from the Meta Ad Library API, or returns simulation data if
- * no token is configured or simulation mode is explicitly set.
- *
- * Token safety:
- *  - The token never appears in log output
- *  - Error messages are redacted before throwing
- *  - paging.next is consumed internally and never logged
- *  - ad_snapshot_url values are logged via safeLog() in the calling script
- */
 export async function fetchMetaAds(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
   const isSimulation = config.simulationMode || !config.token;
 
   if (isSimulation) {
-    const records = getSimulatedRecords();
-    console.log(`\n  Mode: SIMULATION (META_ADLIB_TOKEN not set)`);
+    const records = filterSimulatedRecords(getSimulatedRecords(), config);
+    console.log('\n  Mode: SIMULATION (META_ADLIB_TOKEN not set)');
+    console.log(`  Page IDs: ${config.searchPageIds?.join(', ') ?? '(not set)'}`);
     console.log(`  Returning ${records.length} mock record(s)`);
-    console.log(`  ⚠  This proves normalise → analyse pipeline only.`);
-    console.log(`     Set META_ADLIB_TOKEN to test real API fetch.`);
+    console.log('  ⚠  This proves normalise → analyse pipeline only.');
+    console.log('     Set META_ADLIB_TOKEN to test real API fetch.');
     return records;
   }
 
-  console.log(`\n  Mode: LIVE API FETCH (META_ADLIB_TOKEN detected)`);
+  console.log('\n  Mode: LIVE API FETCH (META_ADLIB_TOKEN detected)');
   return fetchFromApi(config);
 }
 
 // ─── Config builder ───────────────────────────────────────────────────────────
 
-/**
- * Builds MetaFetchConfig from environment variables.
- * All values have safe defaults so the dry-run works with no env vars set.
- *
- * Environment variables:
- *   META_ADLIB_TOKEN    — access token (absent = simulation mode)
- *   META_SEARCH_TERMS   — keyword(s) passed to search_terms (default: 'skincare')
- *   META_COUNTRIES      — comma-separated ISO codes (default: 'SG')
- *   META_FETCH_LIMIT    — number of ads to fetch (default: 5, max: 25)
- *   META_AD_FORMAT      — 'STATIC' or 'VIDEO' (default: 'STATIC')
- *   META_SIMULATION_MODE — 'true' forces simulation even if token is set
- */
 export function buildConfigFromEnv(): MetaFetchConfig {
   const token = process.env.META_ADLIB_TOKEN || undefined;
   const searchTerms = process.env.META_SEARCH_TERMS ?? 'skincare';
@@ -186,10 +179,15 @@ export function buildConfigFromEnv(): MetaFetchConfig {
   const rawFormat = (process.env.META_AD_FORMAT ?? 'STATIC').toUpperCase();
   const format = rawFormat === 'VIDEO' ? 'VIDEO' : 'STATIC';
   const simulationMode = process.env.META_SIMULATION_MODE === 'true';
+  const searchPageIds = (process.env.META_PAGE_IDS ?? '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
 
   return {
     token,
     searchTerms,
+    searchPageIds: searchPageIds.length > 0 ? searchPageIds : undefined,
     countries,
     adActiveStatus: 'ALL',
     limit,

--- a/lib/providers/meta/fetch.ts
+++ b/lib/providers/meta/fetch.ts
@@ -95,6 +95,10 @@ function filterSimulatedRecords(records: MetaAdRecord[], config: MetaFetchConfig
   return filtered;
 }
 
+function serialisePageIdsForGraphApi(pageIds: string[]): string {
+  return `[${pageIds.join(',')}]`;
+}
+
 // ─── Live fetch ───────────────────────────────────────────────────────────────
 
 async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
@@ -108,10 +112,10 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
   });
 
   if (config.searchPageIds && config.searchPageIds.length > 0) {
-    params.set('search_page_ids', JSON.stringify(config.searchPageIds));
+    params.set('search_page_ids', serialisePageIdsForGraphApi(config.searchPageIds));
   }
 
-  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds?.join(',') ?? ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
+  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds ? serialisePageIdsForGraphApi(config.searchPageIds) : ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
   console.log('\n  Fetching from Meta Ad Library API...');
   console.log(`  Search terms:  ${config.searchTerms || '(empty)'}`);
   console.log(`  Page IDs:      ${config.searchPageIds?.join(', ') ?? '(not set)'}`);

--- a/lib/providers/meta/types.ts
+++ b/lib/providers/meta/types.ts
@@ -48,6 +48,8 @@ export type MetaFetchConfig = {
   token: string | undefined;
   /** search_terms passed to the API */
   searchTerms: string;
+  /** search_page_ids passed to the API, usually from Competitor.metaPageId */
+  searchPageIds?: string[];
   /** ISO country codes, e.g. ['SG'] */
   countries: string[];
   /** ad_active_status — 'ALL' | 'ACTIVE' | 'INACTIVE' */

--- a/scripts/ingest-meta-ads.ts
+++ b/scripts/ingest-meta-ads.ts
@@ -1,8 +1,9 @@
 /**
- * Phase 4 Step 2 — Meta Ad Ingestion: CLI Entry Point
+ * Phase 4 Step 5 — Meta Ad Ingestion targeted by page ID: CLI Entry Point
  *
  * Fetches ads from the Meta Ad Library API for a specific Competitor and writes
  * them to the database as discovered activity (qualified=false, reviewStatus=PENDING).
+ * The competitor must have a saved Meta Page ID before ingestion can run.
  *
  * Usage:
  *   # Dry-run (no DB writes — proves fetch → analyse → plan chain):
@@ -21,6 +22,7 @@
  *   COMPETITOR_ID         — required — Prisma cuid of the target Competitor
  *   META_DRY_RUN          — 'true' skips all DB writes (Competitor read still runs)
  *   META_ADLIB_TOKEN      — access token (absent = simulation mode)
+ *   META_PAGE_IDS         — optional comma-separated page IDs for dry-run/fetch tests; ingestion overrides this with Competitor.metaPageId
  *   META_SEARCH_TERMS     — keyword(s) for the Ad Library query (default: 'skincare')
  *   META_COUNTRIES        — comma-separated ISO codes (default: 'SG')
  *   META_FETCH_LIMIT      — number of ads per page (default: 5, max: 25)
@@ -47,14 +49,16 @@ async function main(): Promise<void> {
   const fetchConfig = buildConfigFromEnv();
 
   console.log('═══════════════════════════════════════════════════════════════');
-  console.log('  Phase 4 Step 2 — Meta Ad Ingestion');
+  console.log('  Phase 4 Step 5 — Meta Ad Ingestion targeted by page ID');
   console.log('═══════════════════════════════════════════════════════════════');
   console.log(`  Mode:          ${dryRun ? 'DRY RUN (no DB writes)' : 'LIVE WRITE'}`);
   console.log(`  Competitor ID: ${competitorId}`);
   console.log(`  Format:        ${fetchConfig.format}`);
   console.log(`  Search terms:  ${fetchConfig.searchTerms}`);
+  console.log(`  Page IDs:      ${fetchConfig.searchPageIds?.join(', ') ?? '(loaded from competitor during ingestion)'}`);
   console.log(`  Countries:     ${fetchConfig.countries.join(', ')}`);
   console.log(`  Limit:         ${fetchConfig.limit}`);
+  console.log('  Note:          Competitor.metaPageId is loaded and enforced after competitor lookup.');
 
   const prisma = new PrismaClient();
 
@@ -89,7 +93,6 @@ async function main(): Promise<void> {
     console.log('═══════════════════════════════════════════════════════════════');
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    // Redact any token that may have leaked into the error message
     console.error('\n❌ Ingestion failed:', redactToken(message));
     process.exit(1);
   } finally {


### PR DESCRIPTION
Implements Phase 4 Step 5. Adds searchPageIds support to the Meta fetch config, sends search_page_ids to the Meta Ad Library API, filters simulation records by page ID, and requires a saved competitor Meta Page ID before ingestion can fetch ads. API-sourced ads still enter as pending review and are not automatically qualified. No schema, scoring, review approval, dashboard, or general UI changes were added.