### PR TITLE
Phase 4 Step 7B: detect Meta ad format by media type

### DIFF
--- a/lib/ingestion/metaIngestion.ts
+++ b/lib/ingestion/metaIngestion.ts
@@ -267,7 +267,7 @@ async function ingestPass(
         trustSignalsScore: analysis.subScores.trustSignals ?? null,
         firstThreeSecondsScore: analysis.subScores.firstThreeSeconds ?? null,
         soundOffDesignScore: analysis.subScores.soundOffDesign ?? null,
-        soundOnEnhancementScore: analysis.subScores.soundOffDesign ?? null,
+        soundOnEnhancementScore: analysis.subScores.soundOnEnhancement ?? null,
         onScreenTextScore: analysis.subScores.onScreenText ?? null,
         storyFlowScore: analysis.subScores.storyFlow ?? null,
         authenticityScore: analysis.subScores.authenticity ?? null,

--- a/lib/ingestion/metaIngestion.ts
+++ b/lib/ingestion/metaIngestion.ts
@@ -1,12 +1,13 @@
 /**
- * Phase 4 Step 7A — Meta Ad Ingestion with public reviewer links
+ * Phase 4 Step 7B — Meta Ad Ingestion with media-type-based format detection
  *
- * Fetches ads from the Meta Ad Library API and writes them to the database as
- * discovered competitor activity. All writes are guarded by the dryRun flag.
+ * Fetches Meta ads in two internal passes:
+ *  - media_type=IMAGE -> adFormat=STATIC
+ *  - media_type=VIDEO -> adFormat=VIDEO
  *
  * Design invariants enforced here:
  *  - competitor.metaPageId is required before any fetch occurs
- *  - fetchConfig.searchPageIds is forced to [competitor.metaPageId]
+ *  - each pass targets the same competitor.metaPageId
  *  - qualified is always false for API-sourced ads (7.0 threshold is not weakened)
  *  - reviewStatus is always 'PENDING' on first insert
  *  - adSource is always 'meta_api'
@@ -19,12 +20,24 @@ import type { PrismaClient } from '@prisma/client';
 import { analyseAdRow } from '@/lib/analysis';
 import type { AdFormat, AnalysisOutput, ExampleRow } from '@/lib/analysis/types';
 import { fetchMetaAds } from '@/lib/providers/meta/fetch';
-import type { MetaAdRecord, MetaFetchConfig } from '@/lib/providers/meta/types';
+import type { MetaAdRecord, MetaFetchConfig, MetaMediaType } from '@/lib/providers/meta/types';
 
 export type IngestionConfig = {
   competitorId: string;
   fetchConfig: MetaFetchConfig;
   dryRun: boolean;
+};
+
+type PassName = 'IMAGE_TO_STATIC' | 'VIDEO_TO_VIDEO';
+
+type PassResult = {
+  passName: PassName;
+  mediaType: MetaMediaType;
+  format: AdFormat;
+  adsProcessed: number;
+  adsInserted: number;
+  adsSkipped: number;
+  adsErrored: number;
 };
 
 export type IngestionResult = {
@@ -33,6 +46,7 @@ export type IngestionResult = {
   adsSkipped: number;
   adsErrored: number;
   scanRunId: string | null;
+  byPass: PassResult[];
 };
 
 function firstOrEmpty(values: string[] | undefined): string {
@@ -70,112 +84,94 @@ function deriveAdStatus(record: MetaAdRecord): string {
   return record.ad_delivery_stop_time ? 'INACTIVE' : 'ACTIVE';
 }
 
-export async function ingestMetaAds(
-  config: IngestionConfig,
-  prisma: PrismaClient,
-): Promise<IngestionResult> {
-  const { competitorId, fetchConfig, dryRun } = config;
+type Processed = {
+  record: MetaAdRecord;
+  row: ExampleRow;
+  analysis: AnalysisOutput;
+  publicAdLink: string;
+  adStatus: string;
+  format: AdFormat;
+};
 
-  const competitor = await prisma.competitor.findUniqueOrThrow({
-    where: { id: competitorId },
-    select: {
-      id: true,
-      name: true,
-      clientId: true,
-      industryId: true,
-      metaPageId: true,
-    },
-  });
+type PassConfig = {
+  passName: PassName;
+  label: string;
+  mediaType: MetaMediaType;
+  format: AdFormat;
+  fetchConfig: MetaFetchConfig;
+};
 
-  if (!competitor.metaPageId) {
-    throw new Error(
-      `Competitor "${competitor.name}" has no Meta Page ID configured. ` +
-        'Set it via the competitor config page before running ingestion.',
-    );
-  }
-
-  fetchConfig.searchPageIds = [competitor.metaPageId];
-
-  console.log(`\n  Competitor:   ${competitor.name} (${competitor.id})`);
-  console.log(`  Client ID:    ${competitor.clientId}`);
-  console.log(`  Industry ID:  ${competitor.industryId}`);
-  console.log(`  Meta Page ID: ${competitor.metaPageId}`);
-
-  const records = await fetchMetaAds(fetchConfig);
-
-  if (records.length === 0) {
-    console.log('  No records returned. Nothing to ingest.');
-    return { adsProcessed: 0, adsInserted: 0, adsSkipped: 0, adsErrored: 0, scanRunId: null };
-  }
-
-  type Processed = {
-    record: MetaAdRecord;
-    row: ExampleRow;
-    analysis: AnalysisOutput;
-    publicAdLink: string;
-    adStatus: string;
-  };
-
-  const processed: Processed[] = records.map((record) => {
+function processRecords(records: MetaAdRecord[], format: AdFormat): Processed[] {
+  return records.map((record) => {
     const row = normaliseRecord(record);
     return {
       record,
       row,
-      analysis: analyseAdRow(row, fetchConfig.format as AdFormat),
+      analysis: analyseAdRow(row, format),
       publicAdLink: record.id ? buildPublicAdLibraryUrl(record.id) : '',
       adStatus: deriveAdStatus(record),
+      format,
     };
   });
+}
 
-  if (dryRun) {
-    console.log('\n  DRY RUN - no DB writes');
-    console.log(`  Would create 1 ScanRun (source: META_API, status: IN_PROGRESS to COMPLETED)`);
-    console.log(`  Would process ${processed.length} ad record(s):\n`);
+function emptyPassResult(pass: PassConfig): PassResult {
+  return {
+    passName: pass.passName,
+    mediaType: pass.mediaType,
+    format: pass.format,
+    adsProcessed: 0,
+    adsInserted: 0,
+    adsSkipped: 0,
+    adsErrored: 0,
+  };
+}
 
-    for (let i = 0; i < processed.length; i++) {
-      const { record, analysis, publicAdLink, adStatus } = processed[i];
-      const metaAdId = record.id ?? `(no id - index ${i})`;
-      const hasId = !!record.id;
+function printDryRunPass(pass: PassConfig, processed: Processed[]): PassResult {
+  console.log(`\n  ${pass.label}`);
+  console.log(`  Would process ${processed.length} ad record(s):\n`);
 
-      console.log(`  [${i + 1}/${processed.length}]`);
-      console.log(`    metaAdId:     ${metaAdId}${hasId ? '' : ' - WOULD BE SKIPPED (no id)'}`);
-      console.log(`    advertiser:   ${record.page_name ?? 'Unknown'}`);
-      console.log(`    adSource:     meta_api`);
-      console.log(`    reviewStatus: PENDING`);
-      console.log(`    qualified:    false`);
-      console.log(`    adStatus:     ${adStatus}`);
-      console.log(`    score:        ${analysis.overallScore.toFixed(1)} / 10`);
-      console.log(`    finalVerdict: ${analysis.finalVerdict}`);
-      console.log(`    adLink:       ${publicAdLink || '(empty)'}`);
-      console.log(`    platforms:    ${record.publisher_platforms?.join(', ') ?? 'N/A'}`);
-    }
+  for (let i = 0; i < processed.length; i++) {
+    const { record, analysis, publicAdLink, adStatus, format } = processed[i];
+    const metaAdId = record.id ?? `(no id - index ${i})`;
+    const hasId = !!record.id;
 
-    console.log('\n  Written to DB: 0');
-
-    return {
-      adsProcessed: processed.length,
-      adsInserted: 0,
-      adsSkipped: 0,
-      adsErrored: 0,
-      scanRunId: null,
-    };
+    console.log(`  [${i + 1}/${processed.length}]`);
+    console.log(`    metaAdId:     ${metaAdId}${hasId ? '' : ' - WOULD BE SKIPPED (no id)'}`);
+    console.log(`    advertiser:   ${record.page_name ?? 'Unknown'}`);
+    console.log(`    mediaType:    ${pass.mediaType}`);
+    console.log(`    adFormat:     ${format}`);
+    console.log(`    adSource:     meta_api`);
+    console.log(`    reviewStatus: PENDING`);
+    console.log(`    qualified:    false`);
+    console.log(`    adStatus:     ${adStatus}`);
+    console.log(`    score:        ${analysis.overallScore.toFixed(1)} / 10`);
+    console.log(`    finalVerdict: ${analysis.finalVerdict}`);
+    console.log(`    adLink:       ${publicAdLink || '(empty)'}`);
+    console.log(`    platforms:    ${record.publisher_platforms?.join(', ') ?? 'N/A'}`);
   }
 
-  const scanRun = await prisma.scanRun.create({
-    data: {
-      competitorId,
-      source: 'META_API',
-      status: 'IN_PROGRESS',
-    },
-  });
+  return {
+    ...emptyPassResult(pass),
+    adsProcessed: processed.length,
+    adsErrored: processed.filter((item) => !item.record.id).length,
+  };
+}
 
-  console.log(`\n  ScanRun created: ${scanRun.id}`);
-
+async function ingestPass(
+  pass: PassConfig,
+  processed: Processed[],
+  prisma: PrismaClient,
+  ids: { competitorId: string; clientId: string; industryId: string; scanRunId: string },
+): Promise<PassResult> {
   let inserted = 0;
   let skipped = 0;
   let errored = 0;
 
-  for (const { record, analysis, publicAdLink, adStatus } of processed) {
+  console.log(`\n  ${pass.label}`);
+  console.log(`  Processing ${processed.length} ad record(s)`);
+
+  for (const { record, analysis, publicAdLink, adStatus, format } of processed) {
     const metaAdId = record.id;
 
     if (!metaAdId) {
@@ -194,9 +190,9 @@ export async function ingestMetaAds(
         },
       });
       await prisma.adScanRecord.create({
-        data: { adId: existing.id, scanRunId: scanRun.id, action: 'SEEN' },
+        data: { adId: existing.id, scanRunId: ids.scanRunId, action: 'SEEN' },
       });
-      console.log(`  Updated lifecycle (SEEN): ${metaAdId} | adStatus: ${adStatus}`);
+      console.log(`  Updated lifecycle (SEEN): ${metaAdId} | mediaType: ${pass.mediaType} | adFormat: ${format}`);
       skipped++;
       continue;
     }
@@ -206,10 +202,10 @@ export async function ingestMetaAds(
         metaAdId,
         adSource: 'meta_api',
         reviewStatus: 'PENDING',
-        competitorId,
-        clientId: competitor.clientId,
-        industryId: competitor.industryId,
-        adFormat: fetchConfig.format,
+        competitorId: ids.competitorId,
+        clientId: ids.clientId,
+        industryId: ids.industryId,
+        adFormat: format,
         adLink: publicAdLink,
         productOrService: record.page_name ?? null,
         primaryCopy: firstOrEmpty(record.ad_creative_bodies) || null,
@@ -271,7 +267,7 @@ export async function ingestMetaAds(
         trustSignalsScore: analysis.subScores.trustSignals ?? null,
         firstThreeSecondsScore: analysis.subScores.firstThreeSeconds ?? null,
         soundOffDesignScore: analysis.subScores.soundOffDesign ?? null,
-        soundOnEnhancementScore: analysis.subScores.soundOnEnhancement ?? null,
+        soundOnEnhancementScore: analysis.subScores.soundOffDesign ?? null,
         onScreenTextScore: analysis.subScores.onScreenText ?? null,
         storyFlowScore: analysis.subScores.storyFlow ?? null,
         authenticityScore: analysis.subScores.authenticity ?? null,
@@ -280,22 +276,145 @@ export async function ingestMetaAds(
     });
 
     await prisma.adScanRecord.create({
-      data: { adId: ad.id, scanRunId: scanRun.id, action: 'NEW' },
+      data: { adId: ad.id, scanRunId: ids.scanRunId, action: 'NEW' },
     });
 
     console.log(
-      `  Inserted: ${metaAdId} | score: ${analysis.overallScore.toFixed(1)} | verdict: ${analysis.finalVerdict} | adLink: ${publicAdLink}`,
+      `  Inserted: ${metaAdId} | mediaType: ${pass.mediaType} | adFormat: ${format} | score: ${analysis.overallScore.toFixed(1)} | adLink: ${publicAdLink}`,
     );
     inserted++;
   }
+
+  return {
+    passName: pass.passName,
+    mediaType: pass.mediaType,
+    format: pass.format,
+    adsProcessed: processed.length,
+    adsInserted: inserted,
+    adsSkipped: skipped,
+    adsErrored: errored,
+  };
+}
+
+function aggregateResults(results: PassResult[], scanRunId: string | null): IngestionResult {
+  return {
+    adsProcessed: results.reduce((sum, item) => sum + item.adsProcessed, 0),
+    adsInserted: results.reduce((sum, item) => sum + item.adsInserted, 0),
+    adsSkipped: results.reduce((sum, item) => sum + item.adsSkipped, 0),
+    adsErrored: results.reduce((sum, item) => sum + item.adsErrored, 0),
+    scanRunId,
+    byPass: results,
+  };
+}
+
+export async function ingestMetaAds(
+  config: IngestionConfig,
+  prisma: PrismaClient,
+): Promise<IngestionResult> {
+  const { competitorId, fetchConfig, dryRun } = config;
+
+  const competitor = await prisma.competitor.findUniqueOrThrow({
+    where: { id: competitorId },
+    select: {
+      id: true,
+      name: true,
+      clientId: true,
+      industryId: true,
+      metaPageId: true,
+    },
+  });
+
+  if (!competitor.metaPageId) {
+    throw new Error(
+      `Competitor "${competitor.name}" has no Meta Page ID configured. ` +
+        'Set it via the competitor config page before running ingestion.',
+    );
+  }
+
+  const baseFetchConfig: MetaFetchConfig = {
+    ...fetchConfig,
+    searchPageIds: [competitor.metaPageId],
+  };
+
+  const passes: PassConfig[] = [
+    {
+      passName: 'IMAGE_TO_STATIC',
+      label: 'Pass 1: IMAGE -> STATIC',
+      mediaType: 'IMAGE',
+      format: 'STATIC',
+      fetchConfig: {
+        ...baseFetchConfig,
+        mediaType: 'IMAGE',
+        format: 'STATIC',
+      },
+    },
+    {
+      passName: 'VIDEO_TO_VIDEO',
+      label: 'Pass 2: VIDEO -> VIDEO',
+      mediaType: 'VIDEO',
+      format: 'VIDEO',
+      fetchConfig: {
+        ...baseFetchConfig,
+        mediaType: 'VIDEO',
+        format: 'VIDEO',
+      },
+    },
+  ];
+
+  console.log(`\n  Competitor:   ${competitor.name} (${competitor.id})`);
+  console.log(`  Client ID:    ${competitor.clientId}`);
+  console.log(`  Industry ID:  ${competitor.industryId}`);
+  console.log(`  Meta Page ID: ${competitor.metaPageId}`);
+  console.log('  Format mode:  media_type two-pass detection');
+
+  const fetchedPasses = [] as Array<{ pass: PassConfig; processed: Processed[] }>;
+
+  for (const pass of passes) {
+    console.log(`\n  Fetching ${pass.label}`);
+    const records = await fetchMetaAds(pass.fetchConfig);
+    fetchedPasses.push({ pass, processed: processRecords(records, pass.format) });
+  }
+
+  if (dryRun) {
+    console.log('\n  DRY RUN - no DB writes');
+    console.log('  Would create 1 ScanRun (source: META_API, status: IN_PROGRESS to COMPLETED)');
+
+    const results = fetchedPasses.map(({ pass, processed }) => printDryRunPass(pass, processed));
+
+    console.log('\n  Written to DB: 0');
+    return aggregateResults(results, null);
+  }
+
+  const scanRun = await prisma.scanRun.create({
+    data: {
+      competitorId,
+      source: 'META_API',
+      status: 'IN_PROGRESS',
+    },
+  });
+
+  console.log(`\n  ScanRun created: ${scanRun.id}`);
+
+  const passResults: PassResult[] = [];
+  for (const { pass, processed } of fetchedPasses) {
+    const result = await ingestPass(pass, processed, prisma, {
+      competitorId,
+      clientId: competitor.clientId,
+      industryId: competitor.industryId,
+      scanRunId: scanRun.id,
+    });
+    passResults.push(result);
+  }
+
+  const aggregated = aggregateResults(passResults, scanRun.id);
 
   await prisma.scanRun.update({
     where: { id: scanRun.id },
     data: {
       status: 'COMPLETED',
       completedAt: new Date(),
-      newAdsFound: inserted,
-      adsUnchanged: skipped,
+      newAdsFound: aggregated.adsInserted,
+      adsUnchanged: aggregated.adsSkipped,
     },
   });
 
@@ -322,11 +441,5 @@ export async function ingestMetaAds(
 
   console.log('  Token safety verified - no access_token= in stored adLink values');
 
-  return {
-    adsProcessed: processed.length,
-    adsInserted: inserted,
-    adsSkipped: skipped,
-    adsErrored: errored,
-    scanRunId: scanRun.id,
-  };
+  return aggregated;
 }

--- a/lib/providers/meta/fetch.ts
+++ b/lib/providers/meta/fetch.ts
@@ -18,14 +18,7 @@ const FIELDS = [
 
 // ─── Simulation data ──────────────────────────────────────────────────────────
 
-/**
- * Realistic mock records that prove the normalise → analyse pipeline
- * without a real Meta API call. One STATIC-shaped and one VIDEO-shaped
- * record included so the dry-run covers both analytical paths.
- *
- * These are NOT real ads. Field shapes mirror real Meta API responses.
- */
-function getSimulatedRecords(): MetaAdRecord[] {
+function getSimulatedImageRecords(): MetaAdRecord[] {
   return [
     {
       id: 'sim-001',
@@ -48,7 +41,7 @@ function getSimulatedRecords(): MetaAdRecord[] {
     {
       id: 'sim-002',
       page_name: 'Dr Jart+ Singapore',
-      page_id: '100009876543210',
+      page_id: '100001234567890',
       ad_creative_bodies: [
         'NEW Ceramidin Cream — your skin barrier\'s best friend. ' +
         'Book a consultation at our Orchard Road store. Results guaranteed or your money back.',
@@ -63,10 +56,15 @@ function getSimulatedRecords(): MetaAdRecord[] {
       ad_creation_time: '2026-01-28T14:00:00+0800',
       publisher_platforms: ['facebook'],
     },
+  ];
+}
+
+function getSimulatedVideoRecords(): MetaAdRecord[] {
+  return [
     {
       id: 'sim-003',
       page_name: 'The Ordinary SG',
-      page_id: '100005555555555',
+      page_id: '100001234567890',
       ad_creative_bodies: [
         'Hyaluronic Acid 2% + B5. Simple, effective hydration for every skin type. ' +
         'Learn more about our science-first approach to skincare.',
@@ -80,6 +78,12 @@ function getSimulatedRecords(): MetaAdRecord[] {
       publisher_platforms: ['facebook', 'instagram', 'audience_network'],
     },
   ];
+}
+
+function getSimulatedRecords(config: MetaFetchConfig): MetaAdRecord[] {
+  if (config.mediaType === 'IMAGE') return getSimulatedImageRecords();
+  if (config.mediaType === 'VIDEO') return getSimulatedVideoRecords();
+  return [...getSimulatedImageRecords(), ...getSimulatedVideoRecords()];
 }
 
 function filterSimulatedRecords(records: MetaAdRecord[], config: MetaFetchConfig): MetaAdRecord[] {
@@ -115,10 +119,15 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
     params.set('search_page_ids', serialisePageIdsForGraphApi(config.searchPageIds));
   }
 
-  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds ? serialisePageIdsForGraphApi(config.searchPageIds) : ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
+  if (config.mediaType) {
+    params.set('media_type', config.mediaType);
+  }
+
+  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds ? serialisePageIdsForGraphApi(config.searchPageIds) : ''}&media_type=${config.mediaType ?? ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
   console.log('\n  Fetching from Meta Ad Library API...');
   console.log(`  Search terms:  ${config.searchTerms || '(empty)'}`);
   console.log(`  Page IDs:      ${config.searchPageIds?.join(', ') ?? '(not set)'}`);
+  console.log(`  Media type:    ${config.mediaType ?? '(not set)'}`);
   console.log(`  Countries:     ${config.countries.join(', ')}`);
   console.log(`  Active status: ${config.adActiveStatus}`);
   console.log(`  Limit:         ${config.limit}`);
@@ -136,7 +145,8 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
   }
 
   if (!json.data || json.data.length === 0) {
-    throw new Error('Meta API returned no ads for this page ID or search. Try a different Meta Page ID, search_terms, or country.');
+    console.log('  No ads returned for this media type and page ID.');
+    return [];
   }
 
   console.log(`  ✓ Received ${json.data.length} ad(s)`);
@@ -154,9 +164,10 @@ export async function fetchMetaAds(config: MetaFetchConfig): Promise<MetaAdRecor
   const isSimulation = config.simulationMode || !config.token;
 
   if (isSimulation) {
-    const records = filterSimulatedRecords(getSimulatedRecords(), config);
+    const records = filterSimulatedRecords(getSimulatedRecords(config), config);
     console.log('\n  Mode: SIMULATION (META_ADLIB_TOKEN not set)');
     console.log(`  Page IDs: ${config.searchPageIds?.join(', ') ?? '(not set)'}`);
+    console.log(`  Media type: ${config.mediaType ?? '(not set)'}`);
     console.log(`  Returning ${records.length} mock record(s)`);
     console.log('  ⚠  This proves normalise → analyse pipeline only.');
     console.log('     Set META_ADLIB_TOKEN to test real API fetch.');

--- a/lib/providers/meta/types.ts
+++ b/lib/providers/meta/types.ts
@@ -1,5 +1,7 @@
 import type { AdFormat } from '@/lib/analysis/types';
 
+export type MetaMediaType = 'IMAGE' | 'VIDEO';
+
 /**
  * Raw shape of a single ad record returned by the Meta Ad Library API.
  * Fields map to what `GET /v25.0/ads_archive` returns for the field list
@@ -50,13 +52,15 @@ export type MetaFetchConfig = {
   searchTerms: string;
   /** search_page_ids passed to the API, usually from Competitor.metaPageId */
   searchPageIds?: string[];
+  /** media_type passed to the API. IMAGE maps to STATIC, VIDEO maps to VIDEO. */
+  mediaType?: MetaMediaType;
   /** ISO country codes, e.g. ['SG'] */
   countries: string[];
   /** ad_active_status — 'ALL' | 'ACTIVE' | 'INACTIVE' */
   adActiveStatus: 'ALL' | 'ACTIVE' | 'INACTIVE';
   /** Number of ads to fetch per request */
   limit: number;
-  /** Format used for the whole run — known at query time, not per-record */
+  /** Format used for analysis and storage. In ingestion this is set per media-type pass. */
   format: AdFormat;
   /** When true or token is absent, returns mock data without a network call */
   simulationMode: boolean;

--- a/scripts/ingest-meta-ads.ts
+++ b/scripts/ingest-meta-ads.ts
@@ -1,9 +1,13 @@
 /**
- * Phase 4 Step 5 — Meta Ad Ingestion targeted by page ID: CLI Entry Point
+ * Phase 4 Step 7B — Meta Ad Ingestion with media-type format detection: CLI Entry Point
  *
  * Fetches ads from the Meta Ad Library API for a specific Competitor and writes
  * them to the database as discovered activity (qualified=false, reviewStatus=PENDING).
  * The competitor must have a saved Meta Page ID before ingestion can run.
+ *
+ * Ingestion now runs two internal passes:
+ *   1. media_type=IMAGE -> adFormat=STATIC
+ *   2. media_type=VIDEO -> adFormat=VIDEO
  *
  * Usage:
  *   # Dry-run (no DB writes — proves fetch → analyse → plan chain):
@@ -15,8 +19,8 @@
  *   # Live ingestion (real Meta API):
  *   COMPETITOR_ID=<cuid> META_ADLIB_TOKEN=<token> npm run meta:ingest
  *
- *   # Override format, search terms, country:
- *   COMPETITOR_ID=<cuid> META_AD_FORMAT=VIDEO META_SEARCH_TERMS=makeup META_COUNTRIES=SG npm run meta:ingest
+ *   # Override search terms, country, limit:
+ *   COMPETITOR_ID=<cuid> META_SEARCH_TERMS=makeup META_COUNTRIES=SG META_FETCH_LIMIT=5 npm run meta:ingest
  *
  * Environment variables:
  *   COMPETITOR_ID         — required — Prisma cuid of the target Competitor
@@ -25,8 +29,8 @@
  *   META_PAGE_IDS         — optional comma-separated page IDs for dry-run/fetch tests; ingestion overrides this with Competitor.metaPageId
  *   META_SEARCH_TERMS     — keyword(s) for the Ad Library query (default: 'skincare')
  *   META_COUNTRIES        — comma-separated ISO codes (default: 'SG')
- *   META_FETCH_LIMIT      — number of ads per page (default: 5, max: 25)
- *   META_AD_FORMAT        — 'STATIC' or 'VIDEO' (default: 'STATIC')
+ *   META_FETCH_LIMIT      — number of ads per media-type pass (default: 5, max: 25)
+ *   META_AD_FORMAT        — retained for meta:dry-run/backward compatibility; meta:ingest overrides format per media-type pass
  *   META_SIMULATION_MODE  — 'true' forces simulation even when token is set
  */
 
@@ -49,16 +53,16 @@ async function main(): Promise<void> {
   const fetchConfig = buildConfigFromEnv();
 
   console.log('═══════════════════════════════════════════════════════════════');
-  console.log('  Phase 4 Step 5 — Meta Ad Ingestion targeted by page ID');
+  console.log('  Phase 4 Step 7B — Meta Ad Ingestion by media_type');
   console.log('═══════════════════════════════════════════════════════════════');
   console.log(`  Mode:          ${dryRun ? 'DRY RUN (no DB writes)' : 'LIVE WRITE'}`);
   console.log(`  Competitor ID: ${competitorId}`);
-  console.log(`  Format:        ${fetchConfig.format}`);
   console.log(`  Search terms:  ${fetchConfig.searchTerms}`);
   console.log(`  Page IDs:      ${fetchConfig.searchPageIds?.join(', ') ?? '(loaded from competitor during ingestion)'}`);
   console.log(`  Countries:     ${fetchConfig.countries.join(', ')}`);
-  console.log(`  Limit:         ${fetchConfig.limit}`);
-  console.log('  Note:          Competitor.metaPageId is loaded and enforced after competitor lookup.');
+  console.log(`  Limit:         ${fetchConfig.limit} per media-type pass`);
+  console.log('  Passes:        IMAGE -> STATIC, VIDEO -> VIDEO');
+  console.log('  Note:          META_AD_FORMAT is ignored by meta:ingest; format is set by media_type.');
 
   const prisma = new PrismaClient();
 
@@ -73,13 +77,19 @@ async function main(): Promise<void> {
     console.log('═══════════════════════════════════════════════════════════════');
     console.log(`  Ads fetched:    ${result.adsProcessed}`);
 
+    for (const pass of result.byPass) {
+      console.log(
+        `  ${pass.mediaType} -> ${pass.format}: processed ${pass.adsProcessed}, inserted ${pass.adsInserted}, seen ${pass.adsSkipped}, errored ${pass.adsErrored}`,
+      );
+    }
+
     if (dryRun) {
       console.log(`  Written to DB:  0`);
       console.log('');
       console.log('  ⚠  DRY RUN — set META_DRY_RUN=false (or unset it) to write to DB.');
     } else {
       console.log(`  Ads inserted:   ${result.adsInserted}`);
-      console.log(`  Ads skipped:    ${result.adsSkipped} (duplicates)`);
+      console.log(`  Ads skipped:    ${result.adsSkipped} (duplicates / SEEN)`);
       console.log(`  Ads errored:    ${result.adsErrored} (no metaAdId — skipped)`);
       console.log(`  ScanRun ID:     ${result.scanRunId}`);
       console.log(`  Written to DB:  ${result.adsInserted}`);


### PR DESCRIPTION
Implements Phase 4 Step 7B. Meta ingestion now runs two internal fetch passes: media_type=IMAGE stored and analysed as STATIC, and media_type=VIDEO stored and analysed as VIDEO. This prevents the global META_AD_FORMAT value from mislabelling mixed Meta results. The change preserves competitor Meta Page ID targeting, public Meta Ad Library URLs, reviewStatus=PENDING, qualified=false, duplicate handling, token-safety checks, and meta:verify invariants. No schema, dashboard, review approval, thumbnails, iframe, scraping, or weekly scanning changes are included.