### PR TITLE
Fix Meta config form JSON response handling

### DIFF
--- a/app/api/competitors/[id]/meta-config/route.ts
+++ b/app/api/competitors/[id]/meta-config/route.ts
@@ -47,6 +47,10 @@ function validateMetaPageId(value: string | null | undefined): string | null | u
   return value;
 }
 
+function isPrismaError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError;
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { id: string } },
@@ -84,9 +88,9 @@ export async function PATCH(
 
     const updatedCompetitor = await updateCompetitorMetaConfig(params.id, data);
 
-    return NextResponse.json({ competitor: updatedCompetitor });
+    return NextResponse.json({ competitor: updatedCompetitor }, { status: 200 });
   } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+    if (isPrismaError(error) && error.code === 'P2025') {
       return NextResponse.json({ error: 'Competitor not found.' }, { status: 404 });
     }
 
@@ -94,7 +98,18 @@ export async function PATCH(
       return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
     }
 
-    const message = error instanceof Error ? error.message : 'Unable to update competitor Meta configuration.';
+    if (isPrismaError(error)) {
+      console.error('[meta-config PATCH] Database error:', error);
+      return NextResponse.json(
+        { error: 'Unexpected server error. Please try again.' },
+        { status: 500 },
+      );
+    }
+
+    const message = error instanceof Error
+      ? error.message
+      : 'Unable to update competitor Meta configuration.';
+
     return NextResponse.json({ error: message }, { status: 400 });
   }
 }

--- a/app/components/CompetitorMetaConfigForm.tsx
+++ b/app/components/CompetitorMetaConfigForm.tsx
@@ -8,6 +8,21 @@ type CompetitorMetaConfigFormProps = {
   metaPageId: string | null;
 };
 
+type MetaConfigResponse = {
+  error?: string;
+};
+
+async function parseJsonSafely(response: Response): Promise<MetaConfigResponse> {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text) as MetaConfigResponse;
+  } catch {
+    return {};
+  }
+}
+
 export default function CompetitorMetaConfigForm({
   competitorId,
   facebookPageUrl,
@@ -35,10 +50,10 @@ export default function CompetitorMetaConfigForm({
         }),
       });
 
-      const payload = (await response.json()) as { error?: string };
+      const payload = await parseJsonSafely(response);
 
       if (!response.ok) {
-        throw new Error(payload.error ?? 'Unable to save Meta configuration.');
+        throw new Error(payload.error ?? `Request failed (${response.status}).`);
       }
 
       setStatusMessage('Meta configuration saved. Refreshing page...');


### PR DESCRIPTION
Fixes the Meta configuration save error where the client could show `Failed to execute 'json' on 'Response': Unexpected end of JSON input`.

Changes:
- The form now reads response text first and parses JSON safely only when a body exists.
- Failed non-JSON or empty responses now show a clean `Request failed (<status>)` fallback instead of a browser JSON parse error.
- The API route now separates validation errors from Prisma/system errors.
- Prisma system errors are logged server-side and returned as a generic JSON 500 response.

No schema, ingestion, scoring, dashboard, meta:verify, or /meta-review changes are included.