### PR TITLE
Phase 4 Step 8A: add Meta API pagination support

### DIFF
--- a/lib/providers/meta/fetch.ts
+++ b/lib/providers/meta/fetch.ts
@@ -2,6 +2,8 @@ import { redactToken } from '@/lib/providers/meta/redact';
 import type { MetaAdRecord, MetaApiResponse, MetaFetchConfig } from '@/lib/providers/meta/types';
 
 const META_API_BASE = 'https://graph.facebook.com/v25.0/ads_archive';
+const META_API_MAX_PAGE_SIZE = 25;
+const PAGE_SAFETY_CAP = 10;
 
 const FIELDS = [
   'ad_creation_time',
@@ -103,15 +105,13 @@ function serialisePageIdsForGraphApi(pageIds: string[]): string {
   return `[${pageIds.join(',')}]`;
 }
 
-// ─── Live fetch ───────────────────────────────────────────────────────────────
-
-async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
+function buildBaseParams(config: MetaFetchConfig, pageSize: number): URLSearchParams {
   const params = new URLSearchParams({
     search_terms: config.searchTerms,
     ad_reached_countries: `['${config.countries.join("','")}']`,
     ad_active_status: config.adActiveStatus,
     fields: FIELDS,
-    limit: String(config.limit),
+    limit: String(pageSize),
     access_token: config.token!,
   });
 
@@ -123,39 +123,89 @@ async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
     params.set('media_type', config.mediaType);
   }
 
-  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds ? serialisePageIdsForGraphApi(config.searchPageIds) : ''}&media_type=${config.mediaType ?? ''}&ad_reached_countries=...&fields=...&limit=${config.limit}&access_token=REDACTED`;
+  return params;
+}
+
+// ─── Live fetch ───────────────────────────────────────────────────────────────
+
+async function fetchFromApi(config: MetaFetchConfig): Promise<MetaAdRecord[]> {
+  const pageSize = Math.min(config.limit, META_API_MAX_PAGE_SIZE);
+  const safeDisplayUrl = `${META_API_BASE}?search_terms=${encodeURIComponent(config.searchTerms)}&search_page_ids=${config.searchPageIds ? serialisePageIdsForGraphApi(config.searchPageIds) : ''}&media_type=${config.mediaType ?? ''}&ad_reached_countries=...&fields=...&limit=${pageSize}&access_token=REDACTED`;
+
   console.log('\n  Fetching from Meta Ad Library API...');
   console.log(`  Search terms:  ${config.searchTerms || '(empty)'}`);
   console.log(`  Page IDs:      ${config.searchPageIds?.join(', ') ?? '(not set)'}`);
   console.log(`  Media type:    ${config.mediaType ?? '(not set)'}`);
   console.log(`  Countries:     ${config.countries.join(', ')}`);
   console.log(`  Active status: ${config.adActiveStatus}`);
-  console.log(`  Limit:         ${config.limit}`);
+  console.log(`  Total limit:   ${config.limit}`);
+  console.log(`  Page size:     ${pageSize}`);
   console.log(`  URL:           ${safeDisplayUrl}`);
 
-  const fullUrl = `${META_API_BASE}?${params.toString()}`;
-  const response = await fetch(fullUrl);
-  const json = (await response.json()) as MetaApiResponse;
+  const collected: MetaAdRecord[] = [];
+  let afterCursor: string | undefined;
+  let pageNum = 0;
+  let stopReason = 'no next page';
 
-  if (json.error) {
-    const safeMessage = redactToken(
-      `Meta API error (code ${json.error.code}): ${json.error.message}`,
-    );
-    throw new Error(safeMessage);
+  while (pageNum < PAGE_SAFETY_CAP && collected.length < config.limit) {
+    pageNum++;
+
+    const params = buildBaseParams(config, pageSize);
+    if (afterCursor) {
+      params.set('after', afterCursor);
+    }
+
+    const fullUrl = `${META_API_BASE}?${params.toString()}`;
+    const response = await fetch(fullUrl);
+    const json = (await response.json()) as MetaApiResponse;
+
+    if (json.error) {
+      const safeMessage = redactToken(
+        `Meta API error (code ${json.error.code}): ${json.error.message}`,
+      );
+      throw new Error(safeMessage);
+    }
+
+    const pageRecords = json.data ?? [];
+    console.log(`  Page ${pageNum}: received ${pageRecords.length} ad(s)`);
+
+    if (pageRecords.length === 0) {
+      stopReason = 'page returned 0 ads';
+      break;
+    }
+
+    collected.push(...pageRecords);
+
+    if (collected.length >= config.limit) {
+      stopReason = 'limit reached';
+      break;
+    }
+
+    const hasNextPage = Boolean(json.paging?.next);
+    const nextCursor = json.paging?.cursors?.after;
+
+    if (!hasNextPage || !nextCursor) {
+      stopReason = 'no next page';
+      break;
+    }
+
+    afterCursor = nextCursor;
   }
 
-  if (!json.data || json.data.length === 0) {
+  if (pageNum >= PAGE_SAFETY_CAP && collected.length < config.limit) {
+    stopReason = `safety cap reached (${PAGE_SAFETY_CAP} pages)`;
+  }
+
+  const result = collected.slice(0, config.limit);
+
+  if (result.length === 0) {
     console.log('  No ads returned for this media type and page ID.');
-    return [];
   }
 
-  console.log(`  ✓ Received ${json.data.length} ad(s)`);
+  console.log(`  Pagination stopped: ${stopReason}`);
+  console.log(`  Total collected: ${result.length} ad(s)`);
 
-  if (json.paging?.next) {
-    console.log('  ℹ  Pagination available — not followed in this step (single page only)');
-  }
-
-  return json.data;
+  return result;
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────

--- a/scripts/ingest-meta-ads.ts
+++ b/scripts/ingest-meta-ads.ts
@@ -1,13 +1,16 @@
 /**
- * Phase 4 Step 7B — Meta Ad Ingestion with media-type format detection: CLI Entry Point
+ * Phase 4 Step 8A — Meta Ad Ingestion with pagination support: CLI Entry Point
  *
  * Fetches ads from the Meta Ad Library API for a specific Competitor and writes
  * them to the database as discovered activity (qualified=false, reviewStatus=PENDING).
  * The competitor must have a saved Meta Page ID before ingestion can run.
  *
- * Ingestion now runs two internal passes:
+ * Ingestion runs two internal passes:
  *   1. media_type=IMAGE -> adFormat=STATIC
  *   2. media_type=VIDEO -> adFormat=VIDEO
+ *
+ * The fetcher follows Meta pagination until the configured total per-pass limit,
+ * no next page, or a hard safety page cap is reached.
  *
  * Usage:
  *   # Dry-run (no DB writes — proves fetch → analyse → plan chain):
@@ -19,8 +22,8 @@
  *   # Live ingestion (real Meta API):
  *   COMPETITOR_ID=<cuid> META_ADLIB_TOKEN=<token> npm run meta:ingest
  *
- *   # Override search terms, country, limit:
- *   COMPETITOR_ID=<cuid> META_SEARCH_TERMS=makeup META_COUNTRIES=SG META_FETCH_LIMIT=5 npm run meta:ingest
+ *   # Override search terms, country, total per-pass limit:
+ *   COMPETITOR_ID=<cuid> META_SEARCH_TERMS=makeup META_COUNTRIES=SG META_FETCH_LIMIT=25 npm run meta:ingest
  *
  * Environment variables:
  *   COMPETITOR_ID         — required — Prisma cuid of the target Competitor
@@ -29,7 +32,7 @@
  *   META_PAGE_IDS         — optional comma-separated page IDs for dry-run/fetch tests; ingestion overrides this with Competitor.metaPageId
  *   META_SEARCH_TERMS     — keyword(s) for the Ad Library query (default: 'skincare')
  *   META_COUNTRIES        — comma-separated ISO codes (default: 'SG')
- *   META_FETCH_LIMIT      — number of ads per media-type pass (default: 5, max: 25)
+ *   META_FETCH_LIMIT      — total maximum ads per media-type pass (default: 5, max: 25)
  *   META_AD_FORMAT        — retained for meta:dry-run/backward compatibility; meta:ingest overrides format per media-type pass
  *   META_SIMULATION_MODE  — 'true' forces simulation even when token is set
  */
@@ -53,14 +56,14 @@ async function main(): Promise<void> {
   const fetchConfig = buildConfigFromEnv();
 
   console.log('═══════════════════════════════════════════════════════════════');
-  console.log('  Phase 4 Step 7B — Meta Ad Ingestion by media_type');
+  console.log('  Phase 4 Step 8A — Meta Ad Ingestion with pagination');
   console.log('═══════════════════════════════════════════════════════════════');
   console.log(`  Mode:          ${dryRun ? 'DRY RUN (no DB writes)' : 'LIVE WRITE'}`);
   console.log(`  Competitor ID: ${competitorId}`);
   console.log(`  Search terms:  ${fetchConfig.searchTerms}`);
   console.log(`  Page IDs:      ${fetchConfig.searchPageIds?.join(', ') ?? '(loaded from competitor during ingestion)'}`);
   console.log(`  Countries:     ${fetchConfig.countries.join(', ')}`);
-  console.log(`  Limit:         ${fetchConfig.limit} per media-type pass`);
+  console.log(`  Limit:         ${fetchConfig.limit} total ads per media-type pass`);
   console.log('  Passes:        IMAGE -> STATIC, VIDEO -> VIDEO');
   console.log('  Note:          META_AD_FORMAT is ignored by meta:ingest; format is set by media_type.');
 


### PR DESCRIPTION
Implements Phase 4 Step 8A. The Meta fetch provider now follows cursor pagination for live Meta API calls until the configured per-media-type total limit is reached, no next page exists, a page returns zero ads, or a hard safety cap of 10 pages is reached.

Safety details:
- `paging.next` is never logged, stored, or used as a raw URL.
- The next page is requested by rebuilding the API request and adding `after=<cursor>`.
- Access tokens remain redacted from all logs.
- Results are sliced to the configured total limit.

The CLI copy is updated to clarify that `META_FETCH_LIMIT` is the total maximum per media-type pass. No schema, ingestion write rules, review UI, dashboard, scoring, thumbnails, iframe, scraping, or scheduling changes are included.