### PR TITLE
Phase 5 Step 1: add Meta-ready competitor audit

### DIFF
--- a/lib/queries/competitors.ts
+++ b/lib/queries/competitors.ts
@@ -14,6 +14,26 @@ export type MetaConfigUpdate = {
   metaPageId?: string | null;
 };
 
+export type MetaReadyCompetitor = {
+  id: string;
+  name: string;
+  facebookPageUrl: string | null;
+  metaPageId: string;
+  lastScannedAt: Date | null;
+  client: { name: string } | null;
+  industry: { name: string } | null;
+  latestScanRun: {
+    id: string;
+    status: string;
+    startedAt: Date;
+    completedAt: Date | null;
+    newAdsFound: number;
+    adsUnchanged: number;
+  } | null;
+  totalMetaAdCount: number;
+  pendingMetaAdCount: number;
+};
+
 export function getCompetitors(filter: CompetitorsFilter = {}) {
   const where: Prisma.CompetitorWhereInput = {};
 
@@ -37,6 +57,81 @@ export function getCompetitors(filter: CompetitorsFilter = {}) {
     take: filter.limit ?? 50,
     skip: filter.offset ?? 0,
   });
+}
+
+export async function getMetaReadyCompetitors(): Promise<MetaReadyCompetitor[]> {
+  const competitors = await db.competitor.findMany({
+    where: {
+      metaPageId: {
+        not: null,
+      },
+      NOT: {
+        metaPageId: '',
+      },
+    },
+    select: {
+      id: true,
+      name: true,
+      facebookPageUrl: true,
+      metaPageId: true,
+      lastScannedAt: true,
+      client: { select: { name: true } },
+      industry: { select: { name: true } },
+      _count: {
+        select: {
+          ads: {
+            where: { adSource: 'meta_api' },
+          },
+        },
+      },
+      scanRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: {
+          id: true,
+          status: true,
+          startedAt: true,
+          completedAt: true,
+          newAdsFound: true,
+          adsUnchanged: true,
+        },
+      },
+    },
+    orderBy: [
+      { lastScannedAt: { sort: 'asc', nulls: 'first' } },
+      { name: 'asc' },
+    ],
+  });
+
+  if (competitors.length === 0) return [];
+
+  const competitorIds = competitors.map((competitor) => competitor.id);
+  const pendingGroups = await db.ad.groupBy({
+    by: ['competitorId'],
+    where: {
+      competitorId: { in: competitorIds },
+      adSource: 'meta_api',
+      reviewStatus: 'PENDING',
+    },
+    _count: { _all: true },
+  });
+
+  const pendingCountByCompetitorId = new Map(
+    pendingGroups.map((group) => [group.competitorId, group._count._all]),
+  );
+
+  return competitors.map((competitor) => ({
+    id: competitor.id,
+    name: competitor.name,
+    facebookPageUrl: competitor.facebookPageUrl,
+    metaPageId: competitor.metaPageId!,
+    lastScannedAt: competitor.lastScannedAt,
+    client: competitor.client,
+    industry: competitor.industry,
+    latestScanRun: competitor.scanRuns[0] ?? null,
+    totalMetaAdCount: competitor._count.ads,
+    pendingMetaAdCount: pendingCountByCompetitorId.get(competitor.id) ?? 0,
+  }));
 }
 
 export function getCompetitorById(id: string) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "verify:runtime": "tsx scripts/verify-runtime.ts",
     "meta:dry-run": "tsx scripts/dry-run-meta-fetch.ts",
     "meta:ingest": "tsx scripts/ingest-meta-ads.ts",
-    "meta:verify": "tsx scripts/verify-meta-ingestion.ts"
+    "meta:verify": "tsx scripts/verify-meta-ingestion.ts",
+    "meta:ready": "tsx scripts/list-ready-competitors.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/scripts/list-ready-competitors.ts
+++ b/scripts/list-ready-competitors.ts
@@ -1,0 +1,136 @@
+/**
+ * Phase 5 Step 1 — Meta-ready competitor readiness audit
+ *
+ * Read-only CLI. No DB writes. No Meta API calls. No token required.
+ *
+ * Usage:
+ *   npm run meta:ready
+ *
+ * Optional:
+ *   META_READY_STALE_DAYS=14 npm run meta:ready
+ */
+
+import { db } from '@/lib/db';
+import { getMetaReadyCompetitors, type MetaReadyCompetitor } from '@/lib/queries/competitors';
+
+function formatDate(date: Date | null): string {
+  if (!date) return 'Never';
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function daysSince(date: Date | null): number | null {
+  if (!date) return null;
+  const diffMs = Date.now() - date.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+function parseStaleDays(): number {
+  const raw = process.env.META_READY_STALE_DAYS;
+  if (!raw) return 7;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return 7;
+  return parsed;
+}
+
+function getReadinessVerdict(competitor: MetaReadyCompetitor, staleDays: number): string {
+  if (competitor.pendingMetaAdCount > 0) {
+    return 'NEEDS REVIEW — pending ads exist';
+  }
+
+  if (!competitor.lastScannedAt) {
+    return 'READY — never scanned';
+  }
+
+  const age = daysSince(competitor.lastScannedAt);
+  if (age !== null && age >= staleDays) {
+    return `READY — stale (${age} days since last scan)`;
+  }
+
+  return 'READY — scanned before';
+}
+
+function formatLatestScan(competitor: MetaReadyCompetitor): string {
+  if (!competitor.latestScanRun) return 'None';
+
+  const scan = competitor.latestScanRun;
+  return `${scan.status} — ${scan.newAdsFound} new, ${scan.adsUnchanged} seen, started ${formatDate(scan.startedAt)}`;
+}
+
+function printCompetitor(competitor: MetaReadyCompetitor, index: number, total: number, staleDays: number): void {
+  const pendingSuffix = competitor.pendingMetaAdCount > 0 ? '  ⚠  review queue has items' : '';
+
+  console.log(`\n[${index}/${total}] ${competitor.name}`);
+  console.log(`  COMPETITOR_ID:   ${competitor.id}`);
+  console.log(`  Meta Page ID:    ${competitor.metaPageId}`);
+  console.log(`  Facebook URL:    ${competitor.facebookPageUrl ?? 'Not set'}`);
+  console.log(`  Client:          ${competitor.client?.name ?? 'Not set'}`);
+  console.log(`  Industry:        ${competitor.industry?.name ?? 'Not set'}`);
+  console.log(`  Last scanned:    ${formatDate(competitor.lastScannedAt)}`);
+  console.log(`  Latest scan:     ${formatLatestScan(competitor)}`);
+  console.log(`  Total Meta ads:  ${competitor.totalMetaAdCount}`);
+  console.log(`  Pending review:  ${competitor.pendingMetaAdCount}${pendingSuffix}`);
+  console.log(`  Verdict:         ${getReadinessVerdict(competitor, staleDays)}`);
+  console.log(
+    `  Dry-run:         COMPETITOR_ID=${competitor.id} META_ADLIB_TOKEN=<token> META_DRY_RUN=true META_SEARCH_TERMS='' META_FETCH_LIMIT=25 npm run meta:ingest`,
+  );
+}
+
+function printSummary(competitors: MetaReadyCompetitor[], staleDays: number): void {
+  const neverScanned = competitors.filter((competitor) => !competitor.lastScannedAt).length;
+  const stale = competitors.filter((competitor) => {
+    const age = daysSince(competitor.lastScannedAt);
+    return age !== null && age >= staleDays;
+  }).length;
+  const pending = competitors.filter((competitor) => competitor.pendingMetaAdCount > 0).length;
+
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log('  SUMMARY');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  Total ready:     ${competitors.length}`);
+  console.log(`  Never scanned:   ${neverScanned}`);
+  console.log(`  Stale:           ${stale}`);
+  console.log(`  Pending review:  ${pending} competitor(s) have pending ads`);
+  console.log('═══════════════════════════════════════════════════════════════');
+}
+
+async function main(): Promise<void> {
+  const staleDays = parseStaleDays();
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Phase 5 Step 1 — Meta Ingestion Readiness Audit');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  Stale threshold: ${staleDays} days (set META_READY_STALE_DAYS to change)`);
+  console.log('  Read-only:       no DB writes, no Meta API calls, no token required.');
+
+  const competitors = await getMetaReadyCompetitors();
+
+  if (competitors.length === 0) {
+    console.log('\nNo competitors are ready for Meta ingestion.');
+    console.log('Add a Meta Page ID on a competitor detail page first.');
+    process.exitCode = 1;
+    return;
+  }
+
+  competitors.forEach((competitor, index) => {
+    printCompetitor(competitor, index + 1, competitors.length, staleDays);
+  });
+
+  printSummary(competitors, staleDays);
+}
+
+main()
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('\n❌ Readiness audit failed:', message);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });


### PR DESCRIPTION
Implements Phase 5 Step 1. Adds a read-only CLI command to list competitors ready for Meta ingestion.

Changes:
- Adds getMetaReadyCompetitors() to lib/queries/competitors.ts.
- Adds scripts/list-ready-competitors.ts.
- Adds npm script meta:ready.

The command requires no Meta token, makes no Meta API calls, and performs no database writes. It lists competitors with saved Meta Page IDs, including COMPETITOR_ID, Meta Page ID, Facebook URL, client, industry, last scanned date, latest scan, total Meta ads, pending review count, readiness verdict, and a safe dry-run command.

No schema, ingestion, fetch, scoring, UI, dashboard, or meta:verify changes are included.