### PR TITLE
Phase 5 Step 5: weekly schedule foundation (dry-run-first, SQLite-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,19 @@ META_FETCH_LIMIT=5
 # Set to true to force simulation mode even when META_ADLIB_TOKEN is set.
 # Simulation mode returns mock records without any network call.
 META_SIMULATION_MODE=true
+
+# ── Scheduled batch (GitHub Actions) ─────────────────────────────────────────
+# Set automatically by the GitHub Actions workflow via SCHEDULED_MODE: 'true'.
+# Set manually only when testing the scheduled script locally.
+SCHEDULED_MODE=
+
+# Required for live batch writes in scheduled mode.
+# Must be stored as a GitHub Secret — never a GitHub Variable or in code.
+# Set to 'true' only after confirming DATABASE_URL points to a hosted network DB.
+META_BATCH_CONFIRM_LIVE=
+
+# Optional: override delay between competitors in ms (default 2000).
+META_BATCH_DELAY_MS=2000
+
+# Optional: set to true to force dry-run mode (no DB writes).
+META_DRY_RUN=

--- a/.github/workflows/meta-batch-weekly.yml
+++ b/.github/workflows/meta-batch-weekly.yml
@@ -1,0 +1,66 @@
+name: Meta Batch Weekly Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode? (no DB writes)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+  # Cron is intentionally disabled until a hosted network database is configured.
+  # Required before enabling:
+  # 1. DATABASE_URL points to hosted Postgres/PlanetScale/Supabase/Railway, not SQLite.
+  # 2. Meta token is set as a GitHub Actions secret.
+  # 3. META_BATCH_CONFIRM_LIVE is set to true as a GitHub Actions secret.
+  # 4. Manual dry-run workflow passes.
+  # 5. Manual live workflow passes and meta:verify confirms correct counts.
+  # schedule:
+  #   - cron: '0 1 * * 1' # Monday 09:00 SGT
+
+jobs:
+  batch-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: meta-batch
+      cancel-in-progress: false
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      META_ADLIB_TOKEN: ${{ secrets.META_ADLIB_TOKEN }}
+      META_BATCH_CONFIRM_LIVE: ${{ secrets.META_BATCH_CONFIRM_LIVE }}
+      META_COUNTRIES: ${{ vars.META_COUNTRIES }}
+      META_SEARCH_TERMS: ${{ vars.META_SEARCH_TERMS }}
+      META_FETCH_LIMIT: ${{ vars.META_FETCH_LIMIT }}
+      META_BATCH_DELAY_MS: ${{ vars.META_BATCH_DELAY_MS }}
+      SCHEDULED_MODE: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prisma generate
+      - name: Validate hosted database URL
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "ERROR: DATABASE_URL is not set. Add a hosted database URL in GitHub Secrets."
+            exit 1
+          fi
+          if echo "$DATABASE_URL" | grep -qE '(^file:|\.db$|\.sqlite$)'; then
+            echo "ERROR: DATABASE_URL appears to point to local SQLite."
+            echo "Scheduled batch requires a hosted network database."
+            exit 1
+          fi
+      - name: Run scheduled batch scan
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            META_DRY_RUN=true npm run meta:batch:scheduled
+          else
+            npm run meta:batch:scheduled
+          fi

--- a/docs/meta-ingestion-operator-guide.md
+++ b/docs/meta-ingestion-operator-guide.md
@@ -433,3 +433,103 @@ Do not include these in Phase 4:
 - Bulk competitor imports.
 
 These belong in later phases.
+
+---
+
+## Scheduled batch scan (Phase 5 Step 5)
+
+### What exists now
+
+A GitHub Actions workflow (`meta-batch-weekly.yml`) and a scheduled-mode script (`meta-batch-scheduled.ts`) have been created as a safe scheduler foundation.
+
+The workflow is **manual-trigger only** (`workflow_dispatch`). The automatic weekly cron is intentionally commented out and must not be enabled until all prerequisites below are met.
+
+### What the scheduled script does differently from `meta:batch`
+
+- Prints a `[SCHEDULED]` header with ISO timestamp at the start of every run — makes it easy to filter in GitHub Actions logs or a log aggregator
+- Warns if `SCHEDULED_MODE` is not set — signals to the operator that this script is intended for CI use, not manual runs
+- Prints a one-line machine-readable summary at the end: `[SCHEDULED:DONE] mode=... competitors=... failed=... inserted=... duration=...`
+- All safety gates remain unchanged: `META_ADLIB_TOKEN` required, `META_BATCH_CONFIRM_LIVE=true` required for live writes, all inserted ads remain `reviewStatus=PENDING` and `qualified=false`
+
+### Current limitations — SQLite / local database
+
+This repo currently uses a local SQLite database file (`file:./dev.db`). The GitHub Actions runner cannot reach a local file. If a live run were attempted on the runner with a local `DATABASE_URL`, all inserted ads would be written to a temporary file on the runner and lost when the job finishes.
+
+The workflow includes a guard step that checks `DATABASE_URL` before any script runs. If the URL matches a local SQLite pattern (`file:`, `.db`, `.sqlite`), the job exits 1 immediately with a clear error. This guard fires in both dry-run and live mode.
+
+### How to trigger a dry-run manually (safe now, no hosted DB required)
+
+You can trigger the workflow at any time to verify the structure works — the SQLite guard will fire and exit 1, which is the correct expected outcome while on a local database.
+
+When you have a hosted DB set in Secrets, the guard will pass and the dry-run will execute against the real database.
+
+Steps:
+
+1. Push a branch containing `.github/workflows/meta-batch-weekly.yml` to GitHub.
+2. Go to GitHub → Actions → "Meta Batch Weekly Scan".
+3. Click "Run workflow".
+4. Leave `dry_run = true` (default).
+5. Click "Run workflow".
+6. View the log — confirm `[SCHEDULED]` header appears.
+
+### GitHub Secrets and Variables to configure
+
+Set these in: GitHub repo → Settings → Secrets and variables → Actions
+
+**Secrets** (encrypted, not visible after saving):
+
+| Secret | Value | Notes |
+|---|---|---|
+| `DATABASE_URL` | Hosted Postgres/PlanetScale URL | Must NOT be a local SQLite path |
+| `META_ADLIB_TOKEN` | Your long-lived Meta access token | Rotates every ~60 days |
+| `META_BATCH_CONFIRM_LIVE` | `true` | Set only when ready for live scheduled writes |
+
+**Variables** (visible, non-sensitive config):
+
+| Variable | Example value | Notes |
+|---|---|---|
+| `META_COUNTRIES` | `SG` | Comma-separated ISO codes |
+| `META_SEARCH_TERMS` | `skincare` | Keyword(s) for Meta Ad Library query |
+| `META_FETCH_LIMIT` | `25` | Ads per media-type pass (max 25) |
+| `META_BATCH_DELAY_MS` | `2000` | Delay between competitors in ms |
+
+### Checklist before enabling the automatic weekly cron
+
+All five conditions must be true before you uncomment the `schedule:` block in `.github/workflows/meta-batch-weekly.yml`:
+
+- [ ] `DATABASE_URL` in GitHub Secrets points to a hosted network database (not a local SQLite file)
+- [ ] `META_ADLIB_TOKEN` in GitHub Secrets is a valid long-lived token
+- [ ] `META_BATCH_CONFIRM_LIVE` in GitHub Secrets is set to `true`
+- [ ] A manual `workflow_dispatch` dry-run has completed successfully (SQLite guard passed, ads shown in dry-run output)
+- [ ] A manual `workflow_dispatch` live run has completed successfully and `meta:verify` has confirmed correct ad counts in the hosted DB
+
+To enable: open `.github/workflows/meta-batch-weekly.yml`, uncomment the `schedule:` block, open a PR, get it reviewed, merge.
+
+### How to disable the workflow
+
+Go to GitHub → Actions → "Meta Batch Weekly Scan" → click the `...` menu → "Disable workflow". No code change required. Re-enable from the same menu.
+
+### Token rotation procedure
+
+Meta long-lived tokens expire after approximately 60 days. When the token expires:
+
+1. Generate a new long-lived token.
+2. Go to GitHub → Settings → Secrets → update `META_ADLIB_TOKEN`.
+3. Trigger a manual `workflow_dispatch` dry-run to confirm the new token works.
+4. No code changes, no branch, no PR required.
+
+### Local test of the scheduled script
+
+To test the scheduled script locally before pushing:
+
+```bash
+META_ADLIB_TOKEN=<token> META_DRY_RUN=true SCHEDULED_MODE=true npm run meta:batch:scheduled
+```
+
+Expected output:
+
+- `[SCHEDULED]` header with ISO timestamp
+- Mode: `DRY RUN — no DB writes`
+- Per-competitor rows with `✓`/`✗` icons
+- `SCHEDULED DRY-RUN SUMMARY` block
+- `[SCHEDULED:DONE]` machine-readable summary line on the last line

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "meta:ingest": "tsx scripts/ingest-meta-ads.ts",
     "meta:verify": "tsx scripts/verify-meta-ingestion.ts",
     "meta:ready": "tsx scripts/list-ready-competitors.ts",
-    "meta:batch": "tsx scripts/batch-ingest-meta-ads.ts"
+    "meta:batch": "tsx scripts/batch-ingest-meta-ads.ts",
+    "meta:batch:scheduled": "tsx scripts/meta-batch-scheduled.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/scripts/meta-batch-scheduled.ts
+++ b/scripts/meta-batch-scheduled.ts
@@ -1,0 +1,315 @@
+/**
+ * Phase 5 Step 5 — Scheduled batch Meta ingestion wrapper
+ *
+ * Thin wrapper around the existing batch ingestion logic, intended for
+ * scheduled / CI use (e.g. GitHub Actions workflow_dispatch or cron).
+ *
+ * All safety gates from the manual batch script remain in place:
+ *   - META_ADLIB_TOKEN must be present
+ *   - META_BATCH_CONFIRM_LIVE=true is required for live DB writes
+ *   - Inserted ads remain reviewStatus=PENDING and qualified=false
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { ingestMetaAds } from '@/lib/ingestion/metaIngestion';
+import { buildConfigFromEnv } from '@/lib/providers/meta/fetch';
+import { redactToken } from '@/lib/providers/meta/redact';
+import { getMetaReadyCompetitors, type MetaReadyCompetitor } from '@/lib/queries/competitors';
+
+const DEFAULT_BATCH_DELAY_MS = 2000;
+
+type BatchMode = {
+  isDryRun: boolean;
+};
+
+type BatchItemResult = {
+  competitorId: string;
+  competitorName: string;
+  status: 'DRY_RUN_OK' | 'LIVE_OK' | 'FAILED';
+  adsProcessed: number;
+  adsInserted: number;
+  adsSkipped: number;
+  adsErrored: number;
+  durationMs: number;
+  errorMessage?: string;
+};
+
+function parseBatchDelayMs(): number {
+  const raw = process.env.META_BATCH_DELAY_MS;
+  if (!raw) return DEFAULT_BATCH_DELAY_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_BATCH_DELAY_MS;
+  return parsed;
+}
+
+function parseCompetitorIdFilter(): Set<string> | null {
+  const raw = process.env.COMPETITOR_IDS;
+  if (!raw || raw.trim() === '') return null;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? new Set(ids) : null;
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function determineBatchMode(): BatchMode {
+  const isDryRun = process.env.META_DRY_RUN === 'true';
+  const isLiveConfirmed = process.env.META_BATCH_CONFIRM_LIVE === 'true';
+
+  if (isDryRun) {
+    return { isDryRun: true };
+  }
+
+  if (!isLiveConfirmed) {
+    throw new Error(
+      'Live batch writes are blocked unless META_BATCH_CONFIRM_LIVE=true is set.\n\n' +
+        'Choose one of:\n\n' +
+        '  Dry-run:    META_ADLIB_TOKEN=<token> META_DRY_RUN=true SCHEDULED_MODE=true npm run meta:batch:scheduled\n' +
+        '  Live write: META_ADLIB_TOKEN=<token> META_BATCH_CONFIRM_LIVE=true SCHEDULED_MODE=true npm run meta:batch:scheduled\n\n' +
+        'Note: live writes require DATABASE_URL to point to a hosted network database, not a local SQLite file.',
+    );
+  }
+
+  return { isDryRun: false };
+}
+
+function assertTokenPresent(): void {
+  if (!process.env.META_ADLIB_TOKEN) {
+    throw new Error(
+      'META_ADLIB_TOKEN is required for batch ingestion.\n' +
+        'Use the token only in the terminal or GitHub Secrets. Do not paste it into chat, code, or GitHub.',
+    );
+  }
+}
+
+function assertScheduledMode(): void {
+  if (process.env.SCHEDULED_MODE !== 'true') {
+    console.warn(
+      '\n  ⚠ Warning: SCHEDULED_MODE is not set.\n' +
+        '  This script is intended for scheduled/CI use.\n' +
+        '  For manual batch ingestion, use: npm run meta:batch\n',
+    );
+  }
+}
+
+function selectCompetitors(
+  competitors: MetaReadyCompetitor[],
+  filter: Set<string> | null,
+): MetaReadyCompetitor[] {
+  if (!filter) return competitors;
+  return competitors.filter((c) => filter.has(c.id));
+}
+
+function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function printScheduledSummary(
+  results: BatchItemResult[],
+  isDryRun: boolean,
+  totalDurationMs: number,
+  startedAt: string,
+): void {
+  const totalInserted = results.reduce((sum, r) => sum + r.adsInserted, 0);
+  const totalProcessed = results.reduce((sum, r) => sum + r.adsProcessed, 0);
+  const totalSkipped = results.reduce((sum, r) => sum + r.adsSkipped, 0);
+  const totalErrored = results.reduce((sum, r) => sum + r.adsErrored, 0);
+  const failed = results.filter((r) => r.status === 'FAILED');
+
+  const LINE =
+    '═══════════════════════════════════════════════════════════════';
+  const DIVIDER =
+    '───────────────────────────────────────────────────────────────';
+
+  console.log(`\n${LINE}`);
+  console.log(`  ${isDryRun ? 'SCHEDULED DRY-RUN SUMMARY' : 'SCHEDULED LIVE WRITE SUMMARY'}`);
+  if (!isDryRun) {
+    console.log('  ⚠ LIVE WRITE MODE');
+  }
+  console.log(`  Started:       ${startedAt}`);
+  console.log(`  Total time:    ${formatDuration(totalDurationMs)}`);
+  console.log(`  Competitors:   ${results.length}  |  Failed: ${failed.length}`);
+  console.log(LINE);
+
+  for (const result of results) {
+    const icon = result.status === 'FAILED' ? '✗' : '✓';
+    console.log(`\n  ${icon}  ${result.competitorName}`);
+    if (result.status === 'FAILED') {
+      console.log(`     Status: FAILED  |  ${result.errorMessage ?? 'Unknown error'}`);
+    } else {
+      const insertLabel = isDryRun ? 'Would insert' : 'Inserted';
+      console.log(
+        `     Status: ${result.status}  |  Fetched: ${result.adsProcessed}  |  ${insertLabel}: ${result.adsInserted}  |  Skipped: ${result.adsSkipped}  |  Errored: ${result.adsErrored}  |  ${formatDuration(result.durationMs)}`,
+      );
+    }
+  }
+
+  console.log(`\n${LINE}`);
+  console.log(`  Ads processed:    ${totalProcessed}`);
+  console.log(`  ${isDryRun ? 'Would insert' : 'Inserted'}:         ${totalInserted}`);
+  console.log(`  ${isDryRun ? 'Would mark seen' : 'Seen'}:          ${totalSkipped}`);
+  console.log(`  ${isDryRun ? 'Would error' : 'Errored'}:           ${totalErrored}`);
+  console.log(`  Written to DB:    ${isDryRun ? 0 : totalInserted}`);
+
+  if (failed.length > 0) {
+    console.log(`\n${DIVIDER}`);
+    console.log(`  ⚠ FAILURES (${failed.length})`);
+    console.log(DIVIDER);
+    for (const result of failed) {
+      console.log(`  ${result.competitorName.padEnd(30)} (${result.competitorId})`);
+      console.log(`  → ${result.errorMessage ?? 'Unknown error'}`);
+    }
+  }
+
+  if (!isDryRun) {
+    console.log(`\n${DIVIDER}`);
+    console.log('  All inserted ads: reviewStatus=PENDING, qualified=false');
+    console.log('  Review and approve at: http://localhost:3000/ads');
+
+    const withInserts = results.filter((r) => r.status === 'LIVE_OK' && r.adsInserted > 0);
+    if (withInserts.length > 0) {
+      console.log(`\n${DIVIDER}`);
+      console.log('  NEXT STEPS — verify each ingest:');
+      console.log('');
+      for (const result of withInserts) {
+        console.log(
+          `  COMPETITOR_ID=${result.competitorId} npm run meta:verify   # ${result.competitorName}`,
+        );
+      }
+      console.log('');
+      console.log('  Review pending ads:');
+      console.log('  http://localhost:3000/ads?reviewStatus=PENDING&adSource=meta_api');
+    }
+  }
+
+  if (isDryRun) {
+    console.log(`\n${DIVIDER}`);
+    console.log('  NEXT STEP — when ready to write to the database:');
+    console.log('');
+    console.log('  Ensure DATABASE_URL points to a hosted network database, then:');
+    console.log(
+      '  META_ADLIB_TOKEN=<token> META_BATCH_CONFIRM_LIVE=true SCHEDULED_MODE=true npm run meta:batch:scheduled',
+    );
+  }
+
+  console.log(LINE);
+
+  console.log(
+    `\n[SCHEDULED:DONE] mode=${isDryRun ? 'DRY_RUN' : 'LIVE'} competitors=${results.length} failed=${failed.length} inserted=${totalInserted} duration=${formatDuration(totalDurationMs)}`,
+  );
+}
+
+async function main(): Promise<void> {
+  const batchStartedAt = Date.now();
+  const startedAtIso = new Date().toISOString();
+
+  console.log(`\n[SCHEDULED] Phase 5 Step 5 — Batch Meta Ingestion — ${startedAtIso}`);
+
+  assertScheduledMode();
+
+  const { isDryRun } = determineBatchMode();
+  assertTokenPresent();
+
+  const filter = parseCompetitorIdFilter();
+  const delayMs = parseBatchDelayMs();
+  const fetchConfig = buildConfigFromEnv();
+  const prisma = new PrismaClient();
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  Phase 5 Step 5 — Scheduled Meta Ingestion');
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(`  Mode:          ${isDryRun ? 'DRY RUN — no DB writes' : 'LIVE WRITE'}`);
+  if (!isDryRun) {
+    console.log('  ⚠ LIVE WRITE MODE: new ads will be inserted as PENDING review records.');
+  }
+  console.log(`  Search terms:  ${fetchConfig.searchTerms || '(empty)'}`);
+  console.log(`  Countries:     ${fetchConfig.countries.join(', ')}`);
+  console.log(`  Limit:         ${fetchConfig.limit} total ads per media-type pass`);
+  console.log(`  Batch delay:   ${delayMs}ms between competitors`);
+  console.log(`  Scope:         ${filter ? Array.from(filter).join(', ') : 'all Meta-ready competitors'}`);
+  console.log('  Token:         detected, never logged');
+
+  try {
+    const readyCompetitors = await getMetaReadyCompetitors();
+    const competitors = selectCompetitors(readyCompetitors, filter);
+
+    if (competitors.length === 0) {
+      console.log('\nNo Meta-ready competitors matched this batch scope.');
+      console.log('Run npm run meta:ready to see available competitors.');
+      process.exitCode = 1;
+      return;
+    }
+
+    const results: BatchItemResult[] = [];
+
+    for (let index = 0; index < competitors.length; index++) {
+      const competitor = competitors[index];
+      const startedAt = Date.now();
+
+      console.log('\n───────────────────────────────────────────────────────────────');
+      console.log(`  [${index + 1}/${competitors.length}] ${competitor.name}`);
+      console.log(`  COMPETITOR_ID: ${competitor.id}`);
+      console.log(`  Meta Page ID:  ${competitor.metaPageId}`);
+      console.log('───────────────────────────────────────────────────────────────');
+
+      try {
+        const result = await ingestMetaAds(
+          { competitorId: competitor.id, fetchConfig: { ...fetchConfig }, dryRun: isDryRun },
+          prisma,
+        );
+
+        results.push({
+          competitorId: competitor.id,
+          competitorName: competitor.name,
+          status: isDryRun ? 'DRY_RUN_OK' : 'LIVE_OK',
+          adsProcessed: result.adsProcessed,
+          adsInserted: result.adsInserted,
+          adsSkipped: result.adsSkipped,
+          adsErrored: result.adsErrored,
+          durationMs: Date.now() - startedAt,
+        });
+      } catch (error: unknown) {
+        const message = redactToken(error instanceof Error ? error.message : String(error));
+        console.error(
+          `\n❌ Scheduled ${isDryRun ? 'dry-run' : 'live write'} failed for ${competitor.name}: ${message}`,
+        );
+
+        results.push({
+          competitorId: competitor.id,
+          competitorName: competitor.name,
+          status: 'FAILED',
+          adsProcessed: 0,
+          adsInserted: 0,
+          adsSkipped: 0,
+          adsErrored: 1,
+          durationMs: Date.now() - startedAt,
+          errorMessage: message,
+        });
+      }
+
+      if (index < competitors.length - 1) {
+        console.log(`\n  Waiting ${delayMs}ms before next competitor...`);
+        await sleep(delayMs);
+      }
+    }
+
+    printScheduledSummary(results, isDryRun, Date.now() - batchStartedAt, startedAtIso);
+
+    if (results.some((r) => r.status === 'FAILED')) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = redactToken(error instanceof Error ? error.message : String(error));
+  console.error('\n❌ Scheduled batch ingestion failed:', message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Implements Phase 5 Step 5 as a safe scheduler foundation.

Changes:
- Adds GitHub Actions workflow for Meta batch scan.
- Workflow is workflow_dispatch only; cron remains commented out.
- Adds SQLite/local DATABASE_URL guard before script execution.
- Adds scripts/meta-batch-scheduled.ts with [SCHEDULED] header and [SCHEDULED:DONE] summary line.
- Adds meta:batch:scheduled script to package.json.
- Documents scheduled batch env vars in .env.example.
- Documents hosted-DB prerequisite checklist in the operator guide.

Safety:
- No schema changes.
- No ingestion logic changes.
- No scoring changes.
- No UI changes.
- No live scheduled writes enabled.
- META_BATCH_CONFIRM_LIVE=true remains required for live writes.
- Local SQLite is blocked in the GitHub Actions workflow.