### PR TITLE
Phase 6 Step 2: enhanced duplicate detection for client import

### DIFF
--- a/data/examples/client-competitor-import.example.csv
+++ b/data/examples/client-competitor-import.example.csv
@@ -9,3 +9,6 @@ Glow Skincare SG,Beauty and Skincare,,The Ordinary SG,https://theordinary.com/en
 Glow Skincare SG,Beauty and Skincare,,Tatcha Singapore,https://www.tatcha.com,,,333444555666777,Japanese luxury skincare
 Glow Skincare SG,Beauty and Skincare,,,,,,,No competitors identified yet for this client
 Tech Startup SG,Technology and SaaS,Project management software,Notion Singapore,,https://www.facebook.com/notion,,444555666777888,Cross-client example: run import twice to see duplicate detection
+PCF Singapore,Early Childhood Education,,My First Skool Global,,,,123456789012345,Phase 6 Step 2 demo: BLOCKED - within-CSV Meta Page ID clash with My First Skool above
+PCF Singapore,Early Childhood Education,,My First Skool Alt,,https://www.facebook.com/myfirstskool,,,Phase 6 Step 2 demo: BLOCKED - within-CSV Facebook URL clash with My First Skool above
+PCF Singapore,Early Childhood Education,,Kiddiwinkie,https://www.kiddiwinkie.com.sg,,,,Phase 6 Step 2 demo: WARN - within-CSV website clash with Kiddiwinkie Schoolhouse above

--- a/docs/client-competitor-import-guide.md
+++ b/docs/client-competitor-import-guide.md
@@ -1,16 +1,18 @@
 # Client and Competitor Import Guide
 
-This guide covers how to import clients, industries, and competitors from a CSV file using the Phase 6 Step 1 import script.
+This guide covers how to import clients, industries, and competitors from a CSV file using the Phase 6 Step 2 import script.
 
 ## Overview
 
 The import script reads a CSV file and safely creates or updates:
 
-- **Industries** — created if the industry name does not exist.
-- **Clients** — created if the client name does not exist; `What They Sell` updated if the field is currently blank.
-- **Competitors** — created under the correct client if they do not already exist. Existing competitors are updated only when new data fills a blank field.
+- **Industries** - created if the industry name does not exist.
+- **Clients** - created if the client name does not exist; `What They Sell` updated if the field is currently blank.
+- **Competitors** - created under the correct client if they do not already exist. Existing competitors are updated only when new data fills a blank field.
 
 Dry-run is the default mode. No database writes occur unless `CLIENT_IMPORT_CONFIRM_WRITE=true` is explicitly set.
+
+The script also detects suspected duplicates before writes happen, including same Meta Page ID, same Facebook URL, similar competitor names, and repeated websites within the CSV.
 
 ## CSV format
 
@@ -24,7 +26,7 @@ Client Name,Industry,What They Sell,Competitor Name,Competitor Website,Facebook 
 | `Industry` | Yes | Creates industry if it does not exist. Slug is auto-generated. |
 | `What They Sell` | No | Sets client description. Skipped if client already has this field. |
 | `Competitor Name` | No | If blank, the row creates/updates the client only |
-| `Competitor Website` | No | Stored as reference only, not written to DB |
+| `Competitor Website` | No | Used for within-CSV duplicate detection. Not written to DB. |
 | `Facebook Page URL` | No | Must start with `https://facebook.com/` or `https://www.facebook.com/` |
 | `Meta Ad Library URL` | No | If `Meta Page ID` is blank, `view_all_page_id=<number>` is extracted automatically |
 | `Meta Page ID` | No | Must be numeric digits only. Takes priority over URL extraction. |
@@ -39,19 +41,69 @@ Client Name,Industry,What They Sell,Competitor Name,Competitor Website,Facebook 
 - Existing `Meta Page ID` and `Facebook Page URL` are never overwritten with a blank value.
 - If an incoming value conflicts with an existing value, the existing value is kept and the conflict is reported in the summary.
 - Competitors imported this way are set to `discoverySource=manual` and `status=APPROVED`.
-- Imported competitors with no Meta Page ID can still be imported — they will appear in the "missing Meta Page ID" section of the summary.
-- Competitors are only automatically scanned after import if they already have a confirmed Meta Page ID. No automatic Meta scan is triggered by this script.
-- If a competitor name already exists under a different client in the database, this is reported as a cross-client match. If that other record has a Meta Page ID and the current row does not, the Meta Page ID is reused and noted in the summary.
+- Imported competitors with no Meta Page ID can still be imported. They will appear in the missing Meta Page ID section of the summary.
+- No automatic Meta scan is triggered by this script.
+
+## Duplicate detection
+
+The script performs multi-signal duplicate detection across both the current CSV and the existing database. Each detected signal is classified as **BLOCKED**, **WARN**, or **INFO**.
+
+### Signal reference
+
+| Signal | Scope | Action | Reason |
+|---|---|---|---|
+| Same Meta Page ID, different name | Same client | **BLOCKED** | Meta Page ID is the advertiser identifier. Two names with the same ID under the same client are the same entity. |
+| Same Facebook Page URL, different name | Same client | **BLOCKED** | A Facebook Page belongs to one advertiser. Two names sharing the same URL under the same client are duplicates. |
+| Same Meta Page ID, different name | Cross-client | INFO | Same advertiser tracked under multiple clients. Expected in some categories. |
+| Same Facebook Page URL, different name | Cross-client | INFO | Informational only. |
+| Same normalised name, different exact name | Same client | WARN | Likely the same advertiser with a name variant, such as `Castlery SG` vs `Castlery Singapore`. Row is created but flagged. |
+| Same normalised name, different exact name | Cross-client | INFO | Informational only. |
+| Exact name | Cross-client | INFO | Same competitor tracked under multiple clients. Expected. Meta Page ID may be carried over automatically. |
+| Same website within CSV | Any | WARN | Two rows in the same file share a website. Row is created but flagged. |
+
+### Name normalisation
+
+Competitor names are normalised for fuzzy matching only. The original name is always stored unchanged.
+
+Normalisation strips common legal suffixes, geographic qualifiers, and punctuation.
+
+Examples:
+
+- `Castlery SG` becomes `castlery`
+- `Castlery Singapore` becomes `castlery`
+- `Castlery Pte Ltd` becomes `castlery`
+- `Dr Jart+ Singapore` becomes `dr jart`
+- `My First Skool` stays `my first skool`
+
+If the normalised form of an incoming competitor matches an existing competitor under the same client, the row is still created but a WARN is shown. If the normalised forms match under a different client, an INFO is shown.
+
+### Meta Page ID reuse from cross-client exact name match
+
+If a competitor name exists exactly under a different client, and that existing record has a Meta Page ID that the incoming row does not, the Meta Page ID is carried over automatically.
+
+This is the only case where automatic reuse occurs. The output labels it clearly so you can verify the advertiser identity.
+
+Fuzzy name matches and URL-only matches are never auto-reused. Those require manual action.
+
+### BLOCKED rows
+
+A BLOCKED row is not created in the database, whether in dry-run simulation or live mode.
+
+To resolve a BLOCKED row:
+
+- Remove the row from the CSV if it is a true duplicate.
+- Use the same competitor name as the existing record to route through the update path.
+- Correct the Meta Page ID or Facebook URL if the incoming data is wrong.
 
 ## Commands
 
-### Dry-run (safe, no writes)
+### Dry-run, safe with no writes
 
 ```bash
 CLIENT_IMPORT_FILE=data/examples/client-competitor-import.example.csv CLIENT_IMPORT_DRY_RUN=true npm run import:clients
 ```
 
-### Live import (writes to database)
+### Live import, writes to database
 
 ```bash
 CLIENT_IMPORT_FILE=data/examples/client-competitor-import.example.csv CLIENT_IMPORT_CONFIRM_WRITE=true npm run import:clients
@@ -71,18 +123,22 @@ The dry-run summary shows:
 
 - Industries that would be created
 - Clients that would be created
-- Clients that would be updated (e.g. `What They Sell` would be populated)
+- Clients that would be updated
 - Competitors that would be created, with a warning for any missing Meta Page IDs
-- Competitors that would be updated (e.g. Meta Page ID or Facebook URL would be filled)
-- Rows with no competitor name — client-only rows that need competitor discovery
+- Competitors that would be updated
+- Rows with no competitor name
 - Duplicate rows in the CSV that would be skipped
-- Cross-client competitor matches found in the database
-- Conflicts between incoming and existing values (existing values always win)
+- Suspected duplicates, including BLOCKED, WARN, and INFO signals
+- Conflicts between incoming and existing values
 - Total rows processed and `Written to DB: 0`
+
+If any rows are BLOCKED, the footer shows a count and reminds you to fix the CSV before running live.
 
 ## Live import output
 
-The live summary shows the same sections, with "would be created/updated" replaced by "created/updated". At the end, if any competitors are missing Meta Page IDs, the summary reminds you to add them via the app and run `npm run meta:ready`.
+The live summary shows the same sections, with "would be created/updated" replaced by "created/updated". BLOCKED rows are confirmed as not created. WARN rows are confirmed as created with a review note.
+
+At the end, if any competitors are missing Meta Page IDs or have suspected duplicates, the summary reminds you to review them before running `npm run meta:ready`.
 
 ## After import
 
@@ -124,7 +180,8 @@ Running the import script twice against the same CSV is safe:
 
 - Industries and clients that already exist are not recreated.
 - Competitors that already exist with the same values are skipped and reported as `already exists with same values`.
-- Only genuinely new data (e.g. a Meta Page ID added to a previously blank field) will be applied.
+- Only genuinely new data, such as a Meta Page ID added to a previously blank field, will be applied.
+- Detection signals may still appear on demo rows that intentionally reuse IDs, URLs, or websites.
 
 ## Common errors
 
@@ -162,7 +219,11 @@ data/examples/client-competitor-import.example.csv
 
 This file demonstrates:
 
-- A client with multiple competitors (some with Meta Page IDs, some without)
+- A client with multiple competitors, some with Meta Page IDs and some without
 - A competitor with Meta Page ID extracted from the Meta Ad Library URL column
 - Client-only rows with no competitor
-- A cross-client competitor (run the import twice to see duplicate detection in action)
+- A cross-client competitor example
+- Three Phase 6 Step 2 detection demo rows at the bottom:
+  - `My First Skool Global` is BLOCKED because it shares a Meta Page ID with `My First Skool`.
+  - `My First Skool Alt` is BLOCKED because it shares a Facebook URL with `My First Skool`.
+  - `Kiddiwinkie` is WARNED because it shares a website with `Kiddiwinkie Schoolhouse`.

--- a/scripts/import-client-competitors.ts
+++ b/scripts/import-client-competitors.ts
@@ -1,20 +1,13 @@
 /**
- * Phase 6 Step 1 — Client and Competitor CSV Import
+ * Phase 6 Step 2 - Client and Competitor CSV Import with Enhanced Duplicate Detection
  *
  * Safely imports clients, industries, and competitors from a CSV file.
  * Dry-run is the default mode. Live writes require CLIENT_IMPORT_CONFIRM_WRITE=true.
  *
- * CSV format:
- *   Client Name,Industry,What They Sell,Competitor Name,Competitor Website,
- *   Facebook Page URL,Meta Ad Library URL,Meta Page ID,Notes
- *
- * Dry-run usage:
- *   CLIENT_IMPORT_FILE=<path> CLIENT_IMPORT_DRY_RUN=true npm run import:clients
- *
- * Live usage:
- *   CLIENT_IMPORT_FILE=<path> CLIENT_IMPORT_CONFIRM_WRITE=true npm run import:clients
- *
- * See docs/client-competitor-import-guide.md for full documentation.
+ * Detection signals:
+ *   BLOCKED - same-client Meta Page ID or Facebook URL clash with a different name. Row not created.
+ *   WARN    - same-client normalised name match, or within-CSV website clash. Row created with warning.
+ *   INFO    - cross-client matches. Informational only.
  */
 
 import { parse } from 'csv-parse/sync';
@@ -24,14 +17,14 @@ import * as path from 'path';
 
 type RawCsvRow = {
   'Client Name': string;
-  'Industry': string;
+  Industry: string;
   'What They Sell': string;
   'Competitor Name': string;
   'Competitor Website': string;
   'Facebook Page URL': string;
   'Meta Ad Library URL': string;
   'Meta Page ID': string;
-  'Notes': string;
+  Notes: string;
 };
 
 type ParsedRow = {
@@ -62,10 +55,22 @@ type ConflictReport = {
   incoming: string;
 };
 
-type CrossClientMatch = {
-  competitorName: string;
-  importingClient: string;
+type SuspectedDuplicate = {
+  incomingName: string;
+  incomingClient: string;
+  existingName: string;
   existingClient: string;
+  matchType:
+    | 'exact-name'
+    | 'meta-page-id'
+    | 'facebook-url'
+    | 'normalized-name'
+    | 'website-within-csv'
+    | 'meta-page-id-within-csv'
+    | 'facebook-url-within-csv';
+  matchValue: string;
+  scope: 'same-client' | 'cross-client';
+  action: 'blocked' | 'warn' | 'info';
   metaPageIdReused: boolean;
   reusedMetaPageId: string | null;
 };
@@ -81,8 +86,12 @@ type ImportSummary = {
   rowsWithNoCompetitor: Array<{ client: string; industry: string }>;
   competitorsMissingMetaPageId: Array<{ name: string; client: string }>;
   duplicatesSkipped: Array<{ name: string; client: string; reason: string }>;
-  crossClientMatches: CrossClientMatch[];
+  suspectedDuplicates: SuspectedDuplicate[];
   conflicts: ConflictReport[];
+};
+
+type ExistingCompetitor = Awaited<ReturnType<PrismaClient['competitor']['findMany']>>[number] & {
+  client: { name: string };
 };
 
 function trimField(value: string | undefined | null): string | null {
@@ -108,6 +117,49 @@ function isNumericString(value: string): boolean {
   return /^\d+$/.test(value);
 }
 
+function normalizeCompetitorName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\b(pte\.?\s*ltd\.?|sdn\.?\s*bhd\.?|ltd\.?|inc\.?|corp\.?|llc\.?|co\.?)\b/g, '')
+    .replace(/\b(singapore|sg|asia|global|international|intl)\b/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeFacebookUrl(url: string): string {
+  return url
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/+$/, '');
+}
+
+function normalizeWebsite(url: string): string {
+  return url
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .replace(/\/+$/, '');
+}
+
+function pushUniqueSuspectedDuplicate(
+  items: SuspectedDuplicate[],
+  item: SuspectedDuplicate,
+): void {
+  const exists = items.some(
+    (d) =>
+      d.incomingName === item.incomingName &&
+      d.incomingClient === item.incomingClient &&
+      d.existingName === item.existingName &&
+      d.existingClient === item.existingClient &&
+      d.matchType === item.matchType &&
+      d.matchValue === item.matchValue,
+  );
+
+  if (!exists) items.push(item);
+}
+
 function readAndParseCsv(filePath: string): { rows: ParsedRow[]; errors: ValidationError[] } {
   const resolved = path.resolve(filePath);
 
@@ -130,7 +182,7 @@ function readAndParseCsv(filePath: string): { rows: ParsedRow[]; errors: Validat
     const rowIndex = i + 2;
 
     const clientName = trimField(raw['Client Name']);
-    const industry = trimField(raw['Industry']);
+    const industry = trimField(raw.Industry);
 
     if (!clientName) {
       errors.push({ rowIndex, message: 'Client Name is required.' });
@@ -138,10 +190,7 @@ function readAndParseCsv(filePath: string): { rows: ParsedRow[]; errors: Validat
     }
 
     if (!industry) {
-      errors.push({
-        rowIndex,
-        message: `Industry is required (Client: ${clientName}).`,
-      });
+      errors.push({ rowIndex, message: `Industry is required (Client: ${clientName}).` });
       continue;
     }
 
@@ -192,7 +241,7 @@ function readAndParseCsv(filePath: string): { rows: ParsedRow[]; errors: Validat
       metaAdLibraryUrl,
       metaPageId,
       metaPageIdSource,
-      notes: trimField(raw['Notes']),
+      notes: trimField(raw.Notes),
     });
   }
 
@@ -217,6 +266,27 @@ function determineImportMode(): { isDryRun: boolean } {
   return { isDryRun: false };
 }
 
+function describeMatch(d: SuspectedDuplicate): string {
+  const location = d.scope === 'same-client' ? 'same client' : `client "${d.existingClient}"`;
+
+  switch (d.matchType) {
+    case 'exact-name':
+      return `Exact name also exists under ${location}`;
+    case 'meta-page-id':
+      return `Meta Page ID ${d.matchValue} already exists on "${d.existingName}" under ${location}`;
+    case 'facebook-url':
+      return `Facebook URL already exists on "${d.existingName}" under ${location}: ${d.matchValue}`;
+    case 'normalized-name':
+      return `Normalised name "${d.matchValue}" matches "${d.existingName}" under ${location}`;
+    case 'website-within-csv':
+      return `Website also appears on "${d.existingName}" under ${location} in this CSV: ${d.matchValue}`;
+    case 'meta-page-id-within-csv':
+      return `Meta Page ID ${d.matchValue} also appears on "${d.existingName}" under ${location} earlier in this CSV`;
+    case 'facebook-url-within-csv':
+      return `Facebook URL also appears on "${d.existingName}" under ${location} earlier in this CSV: ${d.matchValue}`;
+  }
+}
+
 function printSummary(summary: ImportSummary, isDryRun: boolean): void {
   const LINE = '═══════════════════════════════════════════════════════════════';
   const DIVIDER = '───────────────────────────────────────────────────────────────';
@@ -229,16 +299,25 @@ function printSummary(summary: ImportSummary, isDryRun: boolean): void {
       summary.competitorsCreated.length +
       summary.competitorsUpdated.length;
 
+  const blocked = summary.suspectedDuplicates.filter((d) => d.action === 'blocked').length;
+  const warned = summary.suspectedDuplicates.filter((d) => d.action === 'warn').length;
+  const info = summary.suspectedDuplicates.filter((d) => d.action === 'info').length;
+
   console.log(`\n${LINE}`);
   console.log(`  ${isDryRun ? 'CLIENT IMPORT DRY-RUN SUMMARY' : 'CLIENT IMPORT LIVE WRITE SUMMARY'}`);
   console.log(LINE);
   console.log(`  Total rows processed:   ${summary.totalRowsProcessed}`);
   console.log(`  Validation errors:      ${summary.validationErrors.length}`);
   console.log(`  Written to DB:          ${totalWritten}`);
+  if (summary.suspectedDuplicates.length > 0) {
+    console.log(
+      `  Suspected duplicates:   ${summary.suspectedDuplicates.length} (${blocked} blocked, ${warned} warned, ${info} info)`,
+    );
+  }
 
   if (summary.validationErrors.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(`  ⚠ VALIDATION ERRORS (${summary.validationErrors.length}) — rows skipped`);
+    console.log(`  ⚠ VALIDATION ERRORS (${summary.validationErrors.length}) - rows skipped`);
     console.log(DIVIDER);
     for (const e of summary.validationErrors) {
       console.log(`  Row ${e.rowIndex}: ${e.message}`);
@@ -247,42 +326,28 @@ function printSummary(summary: ImportSummary, isDryRun: boolean): void {
 
   if (summary.industriesCreated.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  ${isDryRun ? 'Industries that would be created' : 'Industries created'} (${summary.industriesCreated.length})`,
-    );
+    console.log(`  ${isDryRun ? 'Industries that would be created' : 'Industries created'} (${summary.industriesCreated.length})`);
     console.log(DIVIDER);
-    for (const name of summary.industriesCreated) {
-      console.log(`  + ${name}`);
-    }
+    for (const name of summary.industriesCreated) console.log(`  + ${name}`);
   }
 
   if (summary.clientsCreated.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  ${isDryRun ? 'Clients that would be created' : 'Clients created'} (${summary.clientsCreated.length})`,
-    );
+    console.log(`  ${isDryRun ? 'Clients that would be created' : 'Clients created'} (${summary.clientsCreated.length})`);
     console.log(DIVIDER);
-    for (const name of summary.clientsCreated) {
-      console.log(`  + ${name}`);
-    }
+    for (const name of summary.clientsCreated) console.log(`  + ${name}`);
   }
 
   if (summary.clientsUpdated.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  ${isDryRun ? 'Clients that would be updated' : 'Clients updated'} (${summary.clientsUpdated.length})`,
-    );
+    console.log(`  ${isDryRun ? 'Clients that would be updated' : 'Clients updated'} (${summary.clientsUpdated.length})`);
     console.log(DIVIDER);
-    for (const name of summary.clientsUpdated) {
-      console.log(`  ~ ${name}`);
-    }
+    for (const name of summary.clientsUpdated) console.log(`  ~ ${name}`);
   }
 
   if (summary.competitorsCreated.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  ${isDryRun ? 'Competitors that would be created' : 'Competitors created'} (${summary.competitorsCreated.length})`,
-    );
+    console.log(`  ${isDryRun ? 'Competitors that would be created' : 'Competitors created'} (${summary.competitorsCreated.length})`);
     console.log(DIVIDER);
     for (const c of summary.competitorsCreated) {
       const metaNote = c.hasMetaPageId ? '' : '  ⚠ no Meta Page ID';
@@ -292,41 +357,31 @@ function printSummary(summary: ImportSummary, isDryRun: boolean): void {
 
   if (summary.competitorsUpdated.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  ${isDryRun ? 'Competitors that would be updated' : 'Competitors updated'} (${summary.competitorsUpdated.length})`,
-    );
+    console.log(`  ${isDryRun ? 'Competitors that would be updated' : 'Competitors updated'} (${summary.competitorsUpdated.length})`);
     console.log(DIVIDER);
     for (const c of summary.competitorsUpdated) {
       console.log(`  ~ ${c.name}  (client: ${c.client})`);
-      for (const change of c.changes) {
-        console.log(`      ${change}`);
-      }
+      for (const change of c.changes) console.log(`      ${change}`);
     }
   }
 
   if (summary.rowsWithNoCompetitor.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  Rows with no competitor — client only (${summary.rowsWithNoCompetitor.length})`,
-    );
+    console.log(`  Rows with no competitor - client only (${summary.rowsWithNoCompetitor.length})`);
     console.log(DIVIDER);
     for (const r of summary.rowsWithNoCompetitor) {
-      console.log(`  ${r.client}  (industry: ${r.industry})  — needs competitor discovery`);
+      console.log(`  ${r.client}  (industry: ${r.industry})  - needs competitor discovery`);
     }
   }
 
   if (summary.competitorsMissingMetaPageId.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  Competitors missing Meta Page ID (${summary.competitorsMissingMetaPageId.length})`,
-    );
+    console.log(`  Competitors missing Meta Page ID (${summary.competitorsMissingMetaPageId.length})`);
     console.log(DIVIDER);
     for (const c of summary.competitorsMissingMetaPageId) {
       console.log(`  ⚠ ${c.name}  (client: ${c.client})`);
     }
-    console.log(
-      '  → After import, add Meta Page IDs via the app, then run: npm run meta:ready',
-    );
+    console.log('  → After import, add Meta Page IDs via the app, then run: npm run meta:ready');
   }
 
   if (summary.duplicatesSkipped.length > 0) {
@@ -334,56 +389,75 @@ function printSummary(summary: ImportSummary, isDryRun: boolean): void {
     console.log(`  Duplicate rows skipped (${summary.duplicatesSkipped.length})`);
     console.log(DIVIDER);
     for (const d of summary.duplicatesSkipped) {
-      console.log(`  = ${d.name}  (client: ${d.client})  — ${d.reason}`);
+      console.log(`  = ${d.name}  (client: ${d.client})  - ${d.reason}`);
     }
   }
 
-  if (summary.crossClientMatches.length > 0) {
+  if (summary.suspectedDuplicates.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(
-      `  Competitors found under other clients (${summary.crossClientMatches.length})`,
-    );
+    console.log(`  Suspected duplicates - review required (${summary.suspectedDuplicates.length})`);
     console.log(DIVIDER);
-    for (const m of summary.crossClientMatches) {
-      console.log(
-        `  ℹ ${m.competitorName}  also exists under client "${m.existingClient}"`,
-      );
-      if (m.metaPageIdReused) {
-        console.log(
-          `    → Meta Page ID ${m.reusedMetaPageId} reused from existing record (same advertiser confirmed by name match)`,
-        );
+
+    const allBlocked = summary.suspectedDuplicates.filter((d) => d.action === 'blocked');
+    const allWarned = summary.suspectedDuplicates.filter((d) => d.action === 'warn');
+    const allInfo = summary.suspectedDuplicates.filter((d) => d.action === 'info');
+
+    for (const d of allBlocked) {
+      console.log(`\n  ⛔ [BLOCKED]  "${d.incomingName}"  (client: ${d.incomingClient})`);
+      console.log(`     Match: ${describeMatch(d)}`);
+      console.log('     → Row not created. Correct the CSV or use the existing competitor name.');
+    }
+
+    for (const d of allWarned) {
+      console.log(`\n  ⚠  [WARN]    "${d.incomingName}"  (client: ${d.incomingClient})`);
+      console.log(`     Match: ${describeMatch(d)}`);
+      console.log(`     → Competitor ${isDryRun ? 'would be' : 'was'} created. Verify it is not the same advertiser.`);
+    }
+
+    for (const d of allInfo) {
+      console.log(`\n  ℹ  [INFO]    "${d.incomingName}"  (client: ${d.incomingClient})`);
+      console.log(`     Match: ${describeMatch(d)}`);
+      if (d.metaPageIdReused && d.reusedMetaPageId) {
+        console.log(`     → Meta Page ID ${d.reusedMetaPageId} carried over from cross-client exact name match.`);
+        console.log('        Confirm this is the same advertiser before scanning.');
+      } else if (d.matchType === 'meta-page-id' && d.scope === 'cross-client') {
+        console.log('     → Same Meta Page ID tracked under multiple clients. Expected if the same advertiser competes across both client categories.');
       } else {
-        console.log(`    → Verify this is the same advertiser before reusing Meta Page ID`);
+        console.log('     → Verify this is the same advertiser before reusing Meta Page ID manually.');
       }
     }
   }
 
   if (summary.conflicts.length > 0) {
     console.log(`\n${DIVIDER}`);
-    console.log(`  ⚠ CONFLICTS — existing values kept (${summary.conflicts.length})`);
+    console.log(`  ⚠ CONFLICTS - existing values kept (${summary.conflicts.length})`);
     console.log(DIVIDER);
     for (const c of summary.conflicts) {
       console.log(`  ${c.competitorName}  (client: ${c.clientName})  field: ${c.field}`);
       console.log(`    existing: ${c.existing}`);
       console.log(`    incoming: ${c.incoming}`);
-      console.log(`    → Existing value kept. Update manually via the app if needed.`);
+      console.log('    → Existing value kept. Update manually via the app if needed.');
     }
   }
 
   console.log(`\n${LINE}`);
 
   if (isDryRun) {
-    console.log(`\n  NEXT STEP — to write to the database:`);
-    console.log(
-      `  CLIENT_IMPORT_FILE=<path> CLIENT_IMPORT_CONFIRM_WRITE=true npm run import:clients`,
-    );
+    console.log('\n  NEXT STEP - to write to the database:');
+    console.log('  CLIENT_IMPORT_FILE=<path> CLIENT_IMPORT_CONFIRM_WRITE=true npm run import:clients');
+    if (blocked > 0) {
+      console.log(`\n  ⛔ ${blocked} row(s) are blocked. Fix the CSV before running live import.`);
+    }
     console.log(LINE);
   } else {
     if (summary.competitorsMissingMetaPageId.length > 0) {
       console.log(`\n  ${summary.competitorsMissingMetaPageId.length} competitor(s) need Meta Page IDs.`);
-      console.log(`  Add them via the app, then check readiness: npm run meta:ready`);
-      console.log(LINE);
+      console.log('  Add them via the app, then check readiness: npm run meta:ready');
     }
+    if (summary.suspectedDuplicates.length > 0) {
+      console.log(`\n  Review the ${summary.suspectedDuplicates.length} suspected duplicate(s) above before running npm run meta:ready.`);
+    }
+    console.log(LINE);
   }
 }
 
@@ -403,43 +477,61 @@ async function processImport(
     rowsWithNoCompetitor: [],
     competitorsMissingMetaPageId: [],
     duplicatesSkipped: [],
-    crossClientMatches: [],
+    suspectedDuplicates: [],
     conflicts: [],
   };
+
+  const allExistingCompetitors = (await prisma.competitor.findMany({
+    include: { client: true },
+  })) as ExistingCompetitor[];
+
+  const byNormalizedName = new Map<string, ExistingCompetitor[]>();
+  const byMetaPageId = new Map<string, ExistingCompetitor[]>();
+  const byFacebookUrl = new Map<string, ExistingCompetitor[]>();
+
+  for (const comp of allExistingCompetitors) {
+    const norm = normalizeCompetitorName(comp.name);
+    if (norm) {
+      if (!byNormalizedName.has(norm)) byNormalizedName.set(norm, []);
+      byNormalizedName.get(norm)!.push(comp);
+    }
+
+    if (comp.metaPageId) {
+      if (!byMetaPageId.has(comp.metaPageId)) byMetaPageId.set(comp.metaPageId, []);
+      byMetaPageId.get(comp.metaPageId)!.push(comp);
+    }
+
+    if (comp.facebookPageUrl) {
+      const normUrl = normalizeFacebookUrl(comp.facebookPageUrl);
+      if (!byFacebookUrl.has(normUrl)) byFacebookUrl.set(normUrl, []);
+      byFacebookUrl.get(normUrl)!.push(comp);
+    }
+  }
 
   const seenIndustrySlugs = new Set<string>();
   const seenClientNames = new Set<string>();
   const seenCompetitorKeys = new Set<string>();
+  const seenMetaPageIds = new Map<string, { name: string; client: string }>();
+  const seenFacebookUrls = new Map<string, { name: string; client: string }>();
+  const seenWebsites = new Map<string, { name: string; client: string }>();
 
   for (const row of rows) {
-    const existingIndustry = await prisma.industry.findUnique({
-      where: { slug: row.industrySlug },
-    });
+    const existingIndustry = await prisma.industry.findUnique({ where: { slug: row.industrySlug } });
 
     if (!existingIndustry && !seenIndustrySlugs.has(row.industrySlug)) {
       seenIndustrySlugs.add(row.industrySlug);
       summary.industriesCreated.push(row.industry);
-
-      if (!isDryRun) {
-        await prisma.industry.create({
-          data: { name: row.industry, slug: row.industrySlug },
-        });
-      }
+      if (!isDryRun) await prisma.industry.create({ data: { name: row.industry, slug: row.industrySlug } });
     }
 
-    const existingClient = await prisma.client.findUnique({
-      where: { name: row.clientName },
-    });
+    const existingClient = await prisma.client.findUnique({ where: { name: row.clientName } });
 
     if (!existingClient) {
       if (!seenClientNames.has(row.clientName)) {
         seenClientNames.add(row.clientName);
         summary.clientsCreated.push(row.clientName);
-
         if (!isDryRun) {
-          const industry = await prisma.industry.findUnique({
-            where: { slug: row.industrySlug },
-          });
+          const industry = await prisma.industry.findUnique({ where: { slug: row.industrySlug } });
           await prisma.client.create({
             data: {
               name: row.clientName,
@@ -449,167 +541,254 @@ async function processImport(
           });
         }
       }
-    } else {
-      if (row.whatTheySell && !existingClient.whatTheySell) {
-        if (!summary.clientsUpdated.includes(row.clientName)) {
-          summary.clientsUpdated.push(row.clientName);
-        }
-        if (!isDryRun) {
-          await prisma.client.update({
-            where: { id: existingClient.id },
-            data: { whatTheySell: row.whatTheySell },
-          });
-        }
+    } else if (row.whatTheySell && !existingClient.whatTheySell) {
+      if (!summary.clientsUpdated.includes(row.clientName)) summary.clientsUpdated.push(row.clientName);
+      if (!isDryRun) {
+        await prisma.client.update({ where: { id: existingClient.id }, data: { whatTheySell: row.whatTheySell } });
       }
     }
 
     if (!row.competitorName) {
-      summary.rowsWithNoCompetitor.push({
-        client: row.clientName,
-        industry: row.industry,
-      });
+      summary.rowsWithNoCompetitor.push({ client: row.clientName, industry: row.industry });
       continue;
     }
 
     const competitorKey = `${row.clientName}::${row.competitorName}`;
     if (seenCompetitorKeys.has(competitorKey)) {
-      summary.duplicatesSkipped.push({
-        name: row.competitorName,
-        client: row.clientName,
-        reason: 'duplicate row in CSV',
-      });
+      summary.duplicatesSkipped.push({ name: row.competitorName, client: row.clientName, reason: 'duplicate row in CSV' });
       continue;
     }
     seenCompetitorKeys.add(competitorKey);
 
-    const competitorsWithSameName = await prisma.competitor.findMany({
-      where: { name: row.competitorName },
-      include: { client: true },
-    });
+    let isBlocked = false;
 
-    const otherClientMatches = competitorsWithSameName.filter(
-      (c) => c.client.name !== row.clientName,
-    );
+    if (row.metaPageId) {
+      const prior = seenMetaPageIds.get(row.metaPageId);
+      if (prior && prior.name !== row.competitorName) {
+        const scope = prior.client === row.clientName ? 'same-client' : 'cross-client';
+        const action = scope === 'same-client' ? 'blocked' : 'info';
+        if (action === 'blocked') isBlocked = true;
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: prior.name,
+          existingClient: prior.client,
+          matchType: 'meta-page-id-within-csv',
+          matchValue: row.metaPageId,
+          scope,
+          action,
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
+        });
+      }
+      if (!seenMetaPageIds.has(row.metaPageId)) {
+        seenMetaPageIds.set(row.metaPageId, { name: row.competitorName, client: row.clientName });
+      }
+    }
 
-    for (const match of otherClientMatches) {
-      const alreadyReported = summary.crossClientMatches.some(
-        (m) =>
-          m.competitorName === row.competitorName &&
-          m.existingClient === match.client.name,
-      );
+    if (row.facebookPageUrl) {
+      const normFb = normalizeFacebookUrl(row.facebookPageUrl);
+      const prior = seenFacebookUrls.get(normFb);
+      if (prior && prior.name !== row.competitorName) {
+        const scope = prior.client === row.clientName ? 'same-client' : 'cross-client';
+        const action = scope === 'same-client' ? 'blocked' : 'info';
+        if (action === 'blocked') isBlocked = true;
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: prior.name,
+          existingClient: prior.client,
+          matchType: 'facebook-url-within-csv',
+          matchValue: row.facebookPageUrl,
+          scope,
+          action,
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
+        });
+      }
+      if (!seenFacebookUrls.has(normFb)) {
+        seenFacebookUrls.set(normFb, { name: row.competitorName, client: row.clientName });
+      }
+    }
 
-      if (!alreadyReported) {
-        const canReuseMetaPageId = !row.metaPageId && !!match.metaPageId;
-        summary.crossClientMatches.push({
-          competitorName: row.competitorName,
-          importingClient: row.clientName,
+    if (row.competitorWebsite) {
+      const normSite = normalizeWebsite(row.competitorWebsite);
+      const prior = seenWebsites.get(normSite);
+      if (prior && prior.name !== row.competitorName) {
+        const scope = prior.client === row.clientName ? 'same-client' : 'cross-client';
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: prior.name,
+          existingClient: prior.client,
+          matchType: 'website-within-csv',
+          matchValue: row.competitorWebsite,
+          scope,
+          action: 'warn',
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
+        });
+      }
+      if (!seenWebsites.has(normSite)) {
+        seenWebsites.set(normSite, { name: row.competitorName, client: row.clientName });
+      }
+    }
+
+    if (isBlocked) continue;
+
+    const exactNameMatches = allExistingCompetitors.filter((c) => c.name === row.competitorName);
+    const sameClientExact = exactNameMatches.find((c) => c.client.name === row.clientName) ?? null;
+    const crossClientExact = exactNameMatches.filter((c) => c.client.name !== row.clientName);
+
+    let resolvedMetaPageId = row.metaPageId;
+    let reusedMetaPageIdValue: string | null = null;
+
+    if (!resolvedMetaPageId && crossClientExact.length > 0) {
+      const suggestion = crossClientExact.find((c) => !!c.metaPageId);
+      if (suggestion?.metaPageId) {
+        resolvedMetaPageId = suggestion.metaPageId;
+        reusedMetaPageIdValue = suggestion.metaPageId;
+      }
+    }
+
+    for (const match of crossClientExact) {
+      pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+        incomingName: row.competitorName,
+        incomingClient: row.clientName,
+        existingName: match.name,
+        existingClient: match.client.name,
+        matchType: 'exact-name',
+        matchValue: row.competitorName,
+        scope: 'cross-client',
+        action: 'info',
+        metaPageIdReused: !!reusedMetaPageIdValue && match.metaPageId === reusedMetaPageIdValue,
+        reusedMetaPageId: reusedMetaPageIdValue,
+      });
+    }
+
+    if (resolvedMetaPageId) {
+      const metaMatches = (byMetaPageId.get(resolvedMetaPageId) ?? []).filter((c) => c.name !== row.competitorName);
+      for (const match of metaMatches) {
+        const scope = match.client.name === row.clientName ? 'same-client' : 'cross-client';
+        const action = scope === 'same-client' ? 'blocked' : 'info';
+        if (action === 'blocked') isBlocked = true;
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: match.name,
           existingClient: match.client.name,
-          metaPageIdReused: canReuseMetaPageId,
-          reusedMetaPageId: canReuseMetaPageId ? match.metaPageId : null,
+          matchType: 'meta-page-id',
+          matchValue: resolvedMetaPageId,
+          scope,
+          action,
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
         });
       }
     }
 
-    let resolvedMetaPageId = row.metaPageId;
-    if (!resolvedMetaPageId) {
-      const suggestion = summary.crossClientMatches.find(
-        (m) => m.competitorName === row.competitorName && m.metaPageIdReused,
-      );
-      if (suggestion?.reusedMetaPageId) {
-        resolvedMetaPageId = suggestion.reusedMetaPageId;
+    if (row.facebookPageUrl) {
+      const normFb = normalizeFacebookUrl(row.facebookPageUrl);
+      const fbMatches = (byFacebookUrl.get(normFb) ?? []).filter((c) => c.name !== row.competitorName);
+      for (const match of fbMatches) {
+        const scope = match.client.name === row.clientName ? 'same-client' : 'cross-client';
+        const action = scope === 'same-client' ? 'blocked' : 'info';
+        if (action === 'blocked') isBlocked = true;
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: match.name,
+          existingClient: match.client.name,
+          matchType: 'facebook-url',
+          matchValue: row.facebookPageUrl,
+          scope,
+          action,
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
+        });
       }
     }
 
-    const existingCompetitor = competitorsWithSameName.find(
-      (c) => c.client.name === row.clientName,
-    );
+    const normIncoming = normalizeCompetitorName(row.competitorName);
+    if (normIncoming) {
+      const normMatches = (byNormalizedName.get(normIncoming) ?? []).filter((c) => c.name !== row.competitorName);
+      for (const match of normMatches) {
+        const scope = match.client.name === row.clientName ? 'same-client' : 'cross-client';
+        pushUniqueSuspectedDuplicate(summary.suspectedDuplicates, {
+          incomingName: row.competitorName,
+          incomingClient: row.clientName,
+          existingName: match.name,
+          existingClient: match.client.name,
+          matchType: 'normalized-name',
+          matchValue: normIncoming,
+          scope,
+          action: scope === 'same-client' ? 'warn' : 'info',
+          metaPageIdReused: false,
+          reusedMetaPageId: null,
+        });
+      }
+    }
 
-    if (existingCompetitor) {
+    if (isBlocked) continue;
+
+    if (sameClientExact) {
       const changes: string[] = [];
       const updateData: Record<string, string> = {};
 
       if (resolvedMetaPageId) {
-        if (existingCompetitor.metaPageId) {
-          if (existingCompetitor.metaPageId !== resolvedMetaPageId) {
+        if (sameClientExact.metaPageId) {
+          if (sameClientExact.metaPageId !== resolvedMetaPageId) {
             summary.conflicts.push({
               competitorName: row.competitorName,
               clientName: row.clientName,
               field: 'metaPageId',
-              existing: existingCompetitor.metaPageId,
+              existing: sameClientExact.metaPageId,
               incoming: resolvedMetaPageId,
             });
           }
         } else {
-          updateData['metaPageId'] = resolvedMetaPageId;
+          updateData.metaPageId = resolvedMetaPageId;
           changes.push(`metaPageId: (none) → ${resolvedMetaPageId}`);
         }
       }
 
       if (row.facebookPageUrl) {
-        if (existingCompetitor.facebookPageUrl) {
-          if (existingCompetitor.facebookPageUrl !== row.facebookPageUrl) {
+        if (sameClientExact.facebookPageUrl) {
+          if (sameClientExact.facebookPageUrl !== row.facebookPageUrl) {
             summary.conflicts.push({
               competitorName: row.competitorName,
               clientName: row.clientName,
               field: 'facebookPageUrl',
-              existing: existingCompetitor.facebookPageUrl,
+              existing: sameClientExact.facebookPageUrl,
               incoming: row.facebookPageUrl,
             });
           }
         } else {
-          updateData['facebookPageUrl'] = row.facebookPageUrl;
+          updateData.facebookPageUrl = row.facebookPageUrl;
           changes.push(`facebookPageUrl: (none) → ${row.facebookPageUrl}`);
         }
       }
 
       if (changes.length > 0) {
-        summary.competitorsUpdated.push({
-          name: row.competitorName,
-          client: row.clientName,
-          changes,
-        });
-        if (!isDryRun) {
-          await prisma.competitor.update({
-            where: { id: existingCompetitor.id },
-            data: updateData,
-          });
-        }
+        summary.competitorsUpdated.push({ name: row.competitorName, client: row.clientName, changes });
+        if (!isDryRun) await prisma.competitor.update({ where: { id: sameClientExact.id }, data: updateData });
       } else {
-        summary.duplicatesSkipped.push({
-          name: row.competitorName,
-          client: row.clientName,
-          reason: 'already exists with same values',
-        });
+        summary.duplicatesSkipped.push({ name: row.competitorName, client: row.clientName, reason: 'already exists with same values' });
       }
 
-      const finalMetaPageId = resolvedMetaPageId ?? existingCompetitor.metaPageId;
-      if (!finalMetaPageId) {
-        summary.competitorsMissingMetaPageId.push({
-          name: row.competitorName,
-          client: row.clientName,
-        });
+      if (!(resolvedMetaPageId ?? sameClientExact.metaPageId)) {
+        summary.competitorsMissingMetaPageId.push({ name: row.competitorName, client: row.clientName });
       }
     } else {
-      summary.competitorsCreated.push({
-        name: row.competitorName,
-        client: row.clientName,
-        hasMetaPageId: !!resolvedMetaPageId,
-      });
+      summary.competitorsCreated.push({ name: row.competitorName, client: row.clientName, hasMetaPageId: !!resolvedMetaPageId });
 
       if (!resolvedMetaPageId) {
-        summary.competitorsMissingMetaPageId.push({
-          name: row.competitorName,
-          client: row.clientName,
-        });
+        summary.competitorsMissingMetaPageId.push({ name: row.competitorName, client: row.clientName });
       }
 
       if (!isDryRun) {
-        const industry = await prisma.industry.findUnique({
-          where: { slug: row.industrySlug },
-        });
-        const client = await prisma.client.findUnique({
-          where: { name: row.clientName },
-        });
+        const industry = await prisma.industry.findUnique({ where: { slug: row.industrySlug } });
+        const client = await prisma.client.findUnique({ where: { name: row.clientName } });
 
         if (industry && client) {
           await prisma.competitor.create({
@@ -645,18 +824,16 @@ async function main(): Promise<void> {
   }
 
   console.log('\n═══════════════════════════════════════════════════════════════');
-  console.log('  Phase 6 Step 1 — Client and Competitor Import');
+  console.log('  Phase 6 Step 2 - Client and Competitor Import');
   console.log('═══════════════════════════════════════════════════════════════');
-  console.log(`  Mode:  ${isDryRun ? 'DRY RUN — no DB writes' : 'LIVE WRITE'}`);
+  console.log(`  Mode:  ${isDryRun ? 'DRY RUN - no DB writes' : 'LIVE WRITE'}`);
   console.log(`  File:  ${filePath}`);
 
   const { rows, errors } = readAndParseCsv(filePath);
 
   if (errors.length > 0) {
-    console.log(`\n  ⚠ ${errors.length} validation error(s) found — fix before running live import:`);
-    for (const e of errors) {
-      console.log(`    Row ${e.rowIndex}: ${e.message}`);
-    }
+    console.log(`\n  ⚠ ${errors.length} validation error(s) found - fix before running live import:`);
+    for (const e of errors) console.log(`    Row ${e.rowIndex}: ${e.message}`);
     console.log('');
     process.exitCode = 1;
     return;
@@ -669,10 +846,7 @@ async function main(): Promise<void> {
   try {
     const summary = await processImport(rows, isDryRun, prisma);
     printSummary(summary, isDryRun);
-
-    if (summary.validationErrors.length > 0) {
-      process.exitCode = 1;
-    }
+    if (summary.validationErrors.length > 0) process.exitCode = 1;
   } finally {
     await prisma.$disconnect();
   }


### PR DESCRIPTION
Implements Phase 6 Step 2: enhanced duplicate detection and competitor reuse reporting for the client import workflow.

Changes:
- Updates scripts/import-client-competitors.ts with enhanced duplicate detection.
- Updates docs/client-competitor-import-guide.md with BLOCKED/WARN/INFO rules.
- Updates data/examples/client-competitor-import.example.csv with duplicate-detection demo rows.

Behaviour:
- Adds competitor name normalisation for fuzzy matching.
- Detects same-client Meta Page ID clashes and blocks creation.
- Detects same-client Facebook URL clashes and blocks creation.
- Detects same-client normalised-name matches and warns.
- Detects cross-client exact-name, Meta Page ID, Facebook URL, and normalised-name matches as info.
- Detects within-CSV Meta Page ID, Facebook URL, and website clashes.
- Keeps exact-name cross-client Meta Page ID carry-over, but labels it clearly.
- Keeps dry-run/live import safety gates unchanged.

Safety:
- No schema changes.
- No package.json changes.
- No Meta fetching changes.
- No scoring changes.
- No review approval changes.
- No cron changes.
- No hosted database requirement.
- No automatic Meta scanning after import.
- Existing Meta Page IDs and Facebook Page URLs are not overwritten with blanks.